### PR TITLE
Add reward_account support in validator configuration and actions.

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -23,3 +23,10 @@ CUSTOM_JSON_ID=sps
 
 # Logging level
 LOGGING_LEVEL=2
+
+# hive account to broadcast block validation and check in transactions
+VALIDATOR_ACCOUNT=
+VALIDATOR_KEY=
+
+# hive account to direct rewards to - if not supplied they will go to VALIDATOR_ACCOUNT
+REWARD_ACCOUNT=

--- a/apps/sps-validator/src/sps/actions/schema.ts
+++ b/apps/sps-validator/src/sps/actions/schema.ts
@@ -161,6 +161,7 @@ const validate_block = new Schema.Schema(
     object({
         block_num: number().integer().required(),
         hash: string().required(),
+        reward_account: Schema.hiveAccount.optional(),
     }),
 );
 
@@ -396,6 +397,7 @@ const check_in_validator = new Schema.Schema(
     object({
         block_num: number().integer().positive().required(),
         hash: string().required(),
+        reward_account: Schema.hiveAccount.optional(),
     }),
 );
 

--- a/apps/sps-validator/src/sps/actions/validator/check_in_validator.test.ts
+++ b/apps/sps-validator/src/sps/actions/validator/check_in_validator.test.ts
@@ -124,7 +124,7 @@ test.dbOnly('check_in_validator for invalid reward_account fails', async () => {
     const checkIn = await fixture.testHelper.getCheckIn('notanaccount');
     expect(checkIn).toBeNull();
 
-    // should be in the validator reward pool
+    // shouldnt be in the validator reward pool
     const runningLicenses = await fixture.testHelper.getDummyToken('notanaccount', TOKENS.RUNNING_LICENSE);
     expect(runningLicenses?.balance ?? 0).toBe(0);
 });

--- a/apps/sps-validator/src/sps/actions/validator/check_in_validator.test.ts
+++ b/apps/sps-validator/src/sps/actions/validator/check_in_validator.test.ts
@@ -26,6 +26,7 @@ beforeEach(async () => {
         .where('group_name', 'sps')
         .where('name', 'validator_rewards')
         .updateItem({ value: JSON.stringify(validator_rewards_settings) });
+    await fixture.testHelper.setHiveAccount('steemmonsters');
     await fixture.testHelper.setHiveAccount('steemmonsters2');
     await fixture.loader.load();
 });

--- a/apps/sps-validator/src/sps/actions/validator/check_in_validator.ts
+++ b/apps/sps-validator/src/sps/actions/validator/check_in_validator.ts
@@ -1,21 +1,34 @@
-import { OperationData, Action, EventLog, Trx, ValidationError, ErrorType } from '@steem-monsters/splinterlands-validator';
+import { OperationData, Action, EventLog, Trx, ValidationError, ErrorType, HiveAccountRepository } from '@steem-monsters/splinterlands-validator';
 import { check_in_validator } from '../schema';
 import { MakeActionFactory, MakeRouter } from '../utils';
 import { SpsValidatorLicenseManager } from '../../features/validator/validator_license.manager';
 
 export class CheckInValidatorAction extends Action<typeof check_in_validator.actionSchema> {
-    constructor(op: OperationData, data: unknown, index: number, private readonly licenseManager: SpsValidatorLicenseManager) {
+    private readonly reward_account: string;
+    constructor(
+        op: OperationData,
+        data: unknown,
+        index: number,
+        private readonly licenseManager: SpsValidatorLicenseManager,
+        private readonly accountRepository: HiveAccountRepository,
+    ) {
         super(check_in_validator, op, data, index);
+        this.reward_account = this.params.reward_account ?? this.op.account;
     }
 
     async validate(trx?: Trx) {
-        const checkIn = await this.licenseManager.getCheckIn(this.op.account, this.op.block_num, trx);
+        const validRewardAccount = await this.accountRepository.onlyHiveAccounts([this.reward_account], trx);
+        if (!validRewardAccount) {
+            throw new ValidationError('The specified reward account does not exist.', this, ErrorType.AccountNotKnown);
+        }
+
+        const checkIn = await this.licenseManager.getCheckIn(this.reward_account, this.op.block_num, trx);
         if (!checkIn.can_check_in) {
             throw new ValidationError('Cannot check in at this block.', this, ErrorType.InvalidCheckIn);
         }
 
         const { block_num, hash } = this.params;
-        const expectedHash = await this.licenseManager.getCheckInHashForBlockNum(block_num, this.op.account, trx);
+        const expectedHash = await this.licenseManager.getCheckInHashForBlockNum(block_num, this.reward_account, trx);
         if (hash !== expectedHash) {
             throw new ValidationError('Invalid check in hash.', this, ErrorType.InvalidCheckIn);
         }
@@ -24,9 +37,9 @@ export class CheckInValidatorAction extends Action<typeof check_in_validator.act
     }
 
     async process(trx?: Trx): Promise<EventLog[]> {
-        return [...(await this.licenseManager.checkIn(this, this.op.account, trx))];
+        return [...(await this.licenseManager.checkIn(this, this.reward_account, trx))];
     }
 }
 
-const Builder = MakeActionFactory(CheckInValidatorAction, SpsValidatorLicenseManager);
+const Builder = MakeActionFactory(CheckInValidatorAction, SpsValidatorLicenseManager, HiveAccountRepository);
 export const Router = MakeRouter(check_in_validator.action_name, Builder);

--- a/apps/sps-validator/src/sps/actions/validator/validate_block.test.ts
+++ b/apps/sps-validator/src/sps/actions/validator/validate_block.test.ts
@@ -12,6 +12,7 @@ beforeAll(async () => {
 beforeEach(async () => {
     await fixture.restore();
     await fixture.testHelper.insertDefaultConfiguration();
+    await fixture.testHelper.setHiveAccount('steemmonsters');
     await fixture.testHelper.setHiveAccount('steemmonsters2');
     await fixture.handle.query(ConfigEntity).where('group_name', 'validator').andWhere('name', 'max_block_age').updateItem({ value: '100' });
     await fixture.loader.load();

--- a/apps/sps-validator/src/sps/convict-config.ts
+++ b/apps/sps-validator/src/sps/convict-config.ts
@@ -110,6 +110,13 @@ const schema = {
         default: 25,
         env: 'REPLAY_BATCH_SIZE',
     },
+    reward_account: {
+        format: String,
+        doc: 'The account that receives the rewards',
+        nullable: true,
+        default: null as null | string,
+        env: 'REWARD_ACCOUNT',
+    },
     validator_account: {
         format: String,
         nullable: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       DB: '{ "host": "pg", "port": 5432, "database": "${APP_DATABASE:-validator}", "user": "${APP_USER:-validator}", "password": "${APP_PASSWORD:-validator}" }'
       VALIDATOR_ACCOUNT: ${VALIDATOR_ACCOUNT:-}
       VALIDATOR_KEY: ${VALIDATOR_KEY:-}
+      REWARD_ACCOUNT: ${REWARD_ACCOUNT:-}
     depends_on:
       - pg
 

--- a/validator/src/hive.ts
+++ b/validator/src/hive.ts
@@ -32,7 +32,7 @@ export class HiveClient extends Client {
                 id: this.prefixOpts.custom_json_id,
                 json: {
                     action: 'check_in_validator',
-                    params: { block_num, hash },
+                    params: { block_num, hash, reward_account: this.validatorConfig.reward_account ?? undefined },
                 },
                 account: this.validatorConfig.validator_account,
                 role: 'active',
@@ -51,7 +51,7 @@ export class HiveClient extends Client {
                 id: this.prefixOpts.custom_json_id,
                 json: {
                     action: 'validate_block',
-                    params: { block_num, hash },
+                    params: { block_num, hash, reward_account: this.validatorConfig.reward_account ?? undefined },
                 },
                 account: this.validatorConfig.validator_account,
                 role: 'active',

--- a/validator/src/processor.ts
+++ b/validator/src/processor.ts
@@ -22,6 +22,7 @@ import { isDefined } from './libs/guards';
 import { Trx } from './lib';
 
 export type ValidatorOpts = {
+    reward_account: string | null;
     validator_account: string | null;
     validator_key: string | null;
 };


### PR DESCRIPTION
Adds a new env var, `REWARD_ACCOUNT`, to give block validation and validator rewards to an account that isn't the one submitting the transactions. 

This allows you to keep the keys for the account that has your license tokens separate from the one that runs the validator node.

In the case of the block validation rewards, you will still need to register the account that is running the validator as the validator node, NOT the `REWARD_ACCOUNT` you have set.