### PR TITLE
Only submit expire promise/checkins tx's if there are any

### DIFF
--- a/apps/sps-validator/src/sps/entities/validator/validator_check_in.ts
+++ b/apps/sps-validator/src/sps/entities/validator/validator_check_in.ts
@@ -24,7 +24,8 @@ export class SpsValidatorCheckInRepository extends BaseRepository {
      * Gets check ins that last checked in before the block_num
      */
     async countExpired(block_num: number, trx?: Trx) {
-        return this.query(ValidatorCheckInEntity, trx).where('last_check_in_block_num', '<', block_num).where('status', 'active').getCount();
+        const count = await this.query(ValidatorCheckInEntity, trx).where('last_check_in_block_num', '<', block_num).where('status', 'active').getCount();
+        return Number(count);
     }
 
     /**

--- a/apps/sps-validator/src/sps/entities/validator/validator_check_in.ts
+++ b/apps/sps-validator/src/sps/entities/validator/validator_check_in.ts
@@ -23,6 +23,13 @@ export class SpsValidatorCheckInRepository extends BaseRepository {
     /**
      * Gets check ins that last checked in before the block_num
      */
+    async countExpired(block_num: number, trx?: Trx) {
+        return this.query(ValidatorCheckInEntity, trx).where('last_check_in_block_num', '<', block_num).where('status', 'active').getCount();
+    }
+
+    /**
+     * Gets check ins that last checked in before the block_num
+     */
     async getExpired(block_num: number, trx?: Trx) {
         return this.query(ValidatorCheckInEntity, trx).where('last_check_in_block_num', '<', block_num).where('status', 'active').getMany();
     }

--- a/validator/src/entities/promises/promise.ts
+++ b/validator/src/entities/promises/promise.ts
@@ -36,7 +36,7 @@ export class PromiseRepository extends BaseRepository {
 
     async countExpiredPromises(now: Date, trx?: Trx) {
         const count = await this.query(PromiseEntity, trx).where('status', 'fulfilled').where('fulfilled_expiration', '<=', now).getCount();
-        return count;
+        return Number(count);
     }
 
     async getExpiredPromises(now: Date, trx?: Trx): Promise<PromiseEntity[]> {

--- a/validator/src/entities/promises/promise.ts
+++ b/validator/src/entities/promises/promise.ts
@@ -34,6 +34,11 @@ export class PromiseRepository extends BaseRepository {
         return result;
     }
 
+    async countExpiredPromises(now: Date, trx?: Trx) {
+        const count = await this.query(PromiseEntity, trx).where('status', 'fulfilled').where('fulfilled_expiration', '<=', now).getCount();
+        return count;
+    }
+
     async getExpiredPromises(now: Date, trx?: Trx): Promise<PromiseEntity[]> {
         const result = await this.query(PromiseEntity, trx).where('status', 'fulfilled').where('fulfilled_expiration', '<=', now).getMany();
         return result;

--- a/validator/src/features/promises/promise_manager.ts
+++ b/validator/src/features/promises/promise_manager.ts
@@ -51,7 +51,11 @@ export class PromiseManager implements VirtualPayloadSource {
         private readonly promiseRepository: PromiseRepository,
     ) {}
 
-    async process(block: BlockRef): Promise<ProcessResult[]> {
+    async process(block: BlockRef, trx?: Trx): Promise<ProcessResult[]> {
+        const expiredPromises = await this.promiseRepository.countExpiredPromises(block.block_time, trx);
+        if (expiredPromises === 0) {
+            return [];
+        }
         return [
             [
                 'custom_json',


### PR DESCRIPTION
This should improve replay speed because most of the time we don't have any expired promises or check ins.