### PR TITLE
Add staking rewards claim log to event logs for bridges

### DIFF
--- a/apps/sps-validator/src/sps/api/index.ts
+++ b/apps/sps-validator/src/sps/api/index.ts
@@ -19,8 +19,6 @@ import {
 import { utils } from 'splinterlands-dhive-sl';
 import { ManualDisposer } from '../manual-disposable';
 
-//import { HiveClient, ValidatorEventSource, EventDistributorBuilder, PostgresHiveEventSourcesRepository, TokenCheck } from '@steem-monsters/atom';
-
 // Each Middleware allows requests to read (cache) state from 'the world'. What this means is different for each type of middleware.
 
 @injectable()

--- a/sqitch/deploy/appschema.sql
+++ b/sqitch/deploy/appschema.sql
@@ -103,6 +103,9 @@ CREATE TABLE IF NOT EXISTS :APP_SCHEMA.validator_transactions
 
 CREATE INDEX IF NOT EXISTS idx_balance_history_created_date ON :APP_SCHEMA.balance_history USING btree (created_date DESC);
 CREATE INDEX IF NOT EXISTS idx_balance_history_player ON :APP_SCHEMA.balance_history USING btree (player);
+CREATE INDEX IF NOT EXISTS balance_history_token_player_type_idx ON :APP_SCHEMA.balance_history USING btree (token ASC NULLS LAST, player ASC NULLS LAST, type ASC NULLS LAST);
+CREATE INDEX IF NOT EXISTS balance_history_player_created_date_idx ON :APP_SCHEMA.balance_history USING btree (player ASC NULLS LAST, created_date ASC NULLS LAST);
+
 CREATE INDEX IF NOT EXISTS validator_transaction_players_player_idx ON :APP_SCHEMA.validator_transaction_players USING btree (player);
 CREATE INDEX IF NOT EXISTS validator_transactions_block_num_idx ON :APP_SCHEMA.validator_transactions USING btree (block_num);
 CREATE INDEX IF NOT EXISTS validator_transactions_created_date_idx ON :APP_SCHEMA.validator_transactions USING btree (created_date);

--- a/validator/src/entities/event_log.ts
+++ b/validator/src/entities/event_log.ts
@@ -19,7 +19,7 @@ type RemoveSerialKeys<T> = T extends string | number
 export class EventLog<D = any> {
     public readonly object_type: string;
 
-    constructor(public readonly event_type: EventTypes, object_type: TableDescriptor, public readonly data: RemoveSerialKeys<D>) {
+    constructor(public readonly event_type: EventTypes, object_type: TableDescriptor, public readonly data: D) {
         if (typeof object_type === 'function') {
             this.object_type = getTableName(object_type);
         } else {

--- a/validator/src/entities/tokens/staking_rewards.ts
+++ b/validator/src/entities/tokens/staking_rewards.ts
@@ -103,7 +103,11 @@ export class StakingRewardsRepository extends BaseRepository {
 
                 // a record of the claim amount for bridges
                 result.push(
-                    new EventLog(EventTypes.INSERT, StakingRewardsClaim, { player, pool_name: pool_name as string, token: pool.token, amount: claim_amount, pool: pool_name }),
+                    new EventLog(
+                        EventTypes.INSERT,
+                        { table: StakingRewardsClaim.table },
+                        { player, pool_name: pool_name as string, token: pool.token, amount: claim_amount, pool: pool_name },
+                    ),
                 );
             }
         }

--- a/validator/src/entities/tokens/staking_rewards.ts
+++ b/validator/src/entities/tokens/staking_rewards.ts
@@ -37,6 +37,14 @@ type MappedPoolProps = {
 
 export type StakingIncrease = [number, string] | 0; // [amount, token], or just 0 for a claimAll
 
+class StakingRewardsClaim {
+    static table = 'staking_rewards_claim';
+    player!: string;
+    pool_name!: string;
+    token!: string;
+    amount!: number;
+}
+
 export class StakingRewardsRepository extends BaseRepository {
     constructor(
         handle: Handle,
@@ -88,9 +96,14 @@ export class StakingRewardsRepository extends BaseRepository {
                         player,
                         pool.token,
                         claim_amount,
-                        'claim_staking_rewards',
+                        `claim_staking_rewards_${pool_name}`,
                         trx,
                     )),
+                );
+
+                // a record of the claim amount for bridges
+                result.push(
+                    new EventLog(EventTypes.INSERT, StakingRewardsClaim, { player, pool_name: pool_name as string, token: pool.token, amount: claim_amount, pool: pool_name }),
                 );
             }
         }


### PR DESCRIPTION
Adds a ClaimStakingRewards event to the event log for any tx's that claim rewards. This will allow the bridges to listen for claims in specific pools and take action.

Also splits out the claim_rewards type on the balance history insert to include the pool name for reporting.