### PR TITLE
Silence claim pools virt op if there are no pools defined

### DIFF
--- a/apps/sps-validator/src/sps/entities/claims.ts
+++ b/apps/sps-validator/src/sps/entities/claims.ts
@@ -1,9 +1,9 @@
 import { inject, injectable } from 'tsyringe';
-import { PoolClaimPayloads, PrefixOpts } from '@steem-monsters/splinterlands-validator';
+import { PoolClaimPayloads, PoolManager, PrefixOpts } from '@steem-monsters/splinterlands-validator';
 
 @injectable()
 export class SpsPoolClaimPayloads extends PoolClaimPayloads {
-    constructor(@inject(PrefixOpts) cfg: PrefixOpts) {
-        super(cfg);
+    constructor(@inject(PrefixOpts) cfg: PrefixOpts, @inject(PoolManager) poolManager: PoolManager) {
+        super(cfg, poolManager);
     }
 }

--- a/validator/src/entities/claims.ts
+++ b/validator/src/entities/claims.ts
@@ -2,12 +2,16 @@ import { BlockRef } from './block';
 import { Trx } from '../db/tables';
 import { ProcessResult, VirtualPayloadSource } from '../actions/virtual';
 import { PrefixOpts } from './operation';
+import { PoolManager } from '../utilities/pool_manager';
 
 export class PoolClaimPayloads implements VirtualPayloadSource {
     private static pool_payload_account = '$MINTING';
 
-    constructor(private readonly cfg: PrefixOpts) {}
+    constructor(private readonly cfg: PrefixOpts, private readonly poolManager: PoolManager) {}
     async process(block: BlockRef, _?: Trx): Promise<ProcessResult[]> {
+        if (!this.poolManager.anyPools()) {
+            return [];
+        }
         const now = block.block_time;
         return [
             [

--- a/validator/src/libs/pool.ts
+++ b/validator/src/libs/pool.ts
@@ -52,6 +52,10 @@ export class AutonomousPoolsWrapper {
         return undefined;
     }
 
+    public anyPools() {
+        return this.#pools.size > 0;
+    }
+
     public getPool(name: PoolKey): AutonomousPoolConfiguration | undefined {
         if (!this.#pools.has(name)) {
             return undefined;

--- a/validator/src/utilities/pool_manager.ts
+++ b/validator/src/utilities/pool_manager.ts
@@ -29,6 +29,10 @@ export class PoolManager {
         return this.serializer.store(s, trx);
     }
 
+    anyPools() {
+        return this.wrapper?.anyPools() ?? false;
+    }
+
     add(pool: AutonomousPoolConfiguration, aid: ActionIdentifier, trx?: Trx): Promise<EventLog> {
         if (this.wrapper === undefined) {
             throw new AutonomousPoolError(`Trying to add an autonomous pool while pool wrapper is not configured correctly.`, aid, ErrorType.AutonomousPoolInvalid);


### PR DESCRIPTION
not using this at the moment, so no reason to write a transaction that does nothing every block.