### PR TITLE
./run.sh status - Add status command to check validator node and registration status

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ You can take snapshots locally to take backups, and restore them without uploadi
 - `./run.sh rebuild_service <validator | pg | ui>`: force rebuilds a service to apply new environment variables.
 - `./run.sh replay`: rebuilds your node from the snapshot. :warning: **This will irrevocably destroy all local data, including blocks that have already been locally validated**: Be very careful here!
 - `./run.sh destroy`: completely removes the database, validator, and ui. :warning: **This will irrevocably destroy all local data, including blocks that have already been locally validated**: Be very careful here!
+- `./run.sh status`: checks your validator node status and registration status (running/active/inactive)
 
 ## Local development
 

--- a/run.sh
+++ b/run.sh
@@ -253,10 +253,10 @@ status() {
   fi
   
   LOCAL_INFO=$(curl -s --connect-timeout 3 http://localhost:3333/status 2>/dev/null)
-  API_STATUS=$(echo $LOCAL_INFO | grep -o '"status":"[^"]*"' | cut -d':' -f2 | tr -d '"')
+  API_STATUS=$(echo "$LOCAL_INFO" | grep -o '"status":"[^"]*"' | cut -d':' -f2 | tr -d '"')
   
   if [ "$API_STATUS" = "running" ]; then
-    LAST_BLOCK=$(echo $LOCAL_INFO | grep -o '"last_block":[0-9]*' | cut -d':' -f2)
+    LAST_BLOCK=$(echo "$LOCAL_INFO" | grep -o '"last_block":[0-9]*' | cut -d':' -f2)
     echo "- Node status: RUNNING"
     echo "- Last block: $LAST_BLOCK"
     echo "Your Node is synchronized"

--- a/run.sh
+++ b/run.sh
@@ -245,7 +245,7 @@ logs() {
 status() {
   echo "Checking validator status..."
   
-  VALIDATOR_ACC=$(grep "VALIDATOR_ACCOUNT" .env | cut -d '=' -f2 | tr -d '"' | tr -d "'" | xargs)
+  VALIDATOR_ACC="$VALIDATOR_ACCOUNT"
   
   if [ -z "$VALIDATOR_ACC" ]; then
     echo "VALIDATOR_ACCOUNT not found in .env file"

--- a/run.sh
+++ b/run.sh
@@ -242,6 +242,55 @@ logs() {
     docker_compose_wrapper logs validator -f --tail 30
 }
 
+status() {
+  echo "Checking validator status..."
+  
+  VALIDATOR_ACC=$(grep "VALIDATOR_ACCOUNT" .env | cut -d '=' -f2 | tr -d '"' | tr -d "'" | xargs)
+  
+  if [ -z "$VALIDATOR_ACC" ]; then
+    echo "VALIDATOR_ACCOUNT not found in .env file"
+    return 1
+  fi
+  
+  LOCAL_INFO=$(curl -s --connect-timeout 3 http://localhost:3333/status 2>/dev/null)
+  API_STATUS=$(echo $LOCAL_INFO | grep -o '"status":"[^"]*"' | cut -d':' -f2 | tr -d '"')
+  
+  if [ "$API_STATUS" = "running" ]; then
+    LAST_BLOCK=$(echo $LOCAL_INFO | grep -o '"last_block":[0-9]*' | cut -d':' -f2)
+    echo "- Node status: RUNNING"
+    echo "- Last block: $LAST_BLOCK"
+    echo "Your Node is synchronized"
+    API_URL="http://localhost:3333"
+  else
+    echo "Your node isn't running properly. Using the external API instead."
+    API_URL="https://splinterlands-validator-api.splinterlands.com"
+  fi
+  
+  echo ""
+  echo "Validator Account: $VALIDATOR_ACC"
+  
+  VALIDATORS_RESPONSE=$(curl -s $API_URL/validators)
+  NODE_INFO=$(echo "$VALIDATORS_RESPONSE" | grep -o "{[^{]*\"account_name\":\"$VALIDATOR_ACC\"[^}]*}")
+  
+  echo -n "Validator node status: "
+  
+  if [[ $NODE_INFO == *'"is_active":true'* ]]; then
+    echo "ACTIVE"
+  elif [[ $NODE_INFO == *'"is_active":false'* ]]; then
+    echo "INACTIVE"
+  elif [ -z "$NODE_INFO" ]; then
+    echo "Not registered or not found"
+    
+    if [ -z "$LOCAL_INFO" ]; then
+      echo "(Make sure your node is running with './run.sh start')"
+    else
+      echo "(If you've just registered, it might take some time for the registration to be recognized)"
+    fi
+  else
+    echo "Status unclear. Raw data: $NODE_INFO"
+  fi
+}
+
 help() {
     echo "Usage: $0 COMMAND"
     echo
@@ -256,6 +305,7 @@ help() {
     echo "    dl_snapshot                   - downloads snapshot if it doesn't exists locally"
     echo "    snapshot                      - creates a snapshot of the current database."
     echo "    logs                          - trails the last 30 lines of logs"
+    echo "    status                        - checks your validator node status and registration status"
     echo
     echo "Helpers:"
     echo "    install_docker - install docker"
@@ -300,6 +350,9 @@ case $1 in
     ;;
     help)
         help
+    ;;
+    status)
+        status
     ;;
     *)
         echo "Invalid CMD"


### PR DESCRIPTION
Add status command in run.sh to detect and display validator node status.

It display node status, last block, sync, account.

For example, the output looks like this:

./run.sh status
Checking validator status...
- Node status: RUNNING
- Last block: 94230525
Your Node is synchronized

Validator Account: hanv
Validator node status: ACTIVE

This will be helpful for someone running a node on an Ubuntu server without access to a web UI.