### PR TITLE
Improve manage validator node page UX

### DIFF
--- a/apps/sps-validator-ui/src/app/pages/ManageValidatorNode.tsx
+++ b/apps/sps-validator-ui/src/app/pages/ManageValidatorNode.tsx
@@ -53,11 +53,21 @@ function RegisterCard({ account, registered }: { account: string; registered: ()
     const [apiUrl, setApiUrl] = useState('');
     const [rewardAccount, setRewardAccount] = useState('');
     const [error, setError] = useState('');
+    const [rewardAccountError, setRewardAccountError] = useState('');
     const [progress, setProgress] = useState(false);
 
     const register = async () => {
         setProgress(true);
         setError('');
+        setRewardAccountError('');
+        
+        // Prevent user from setting their own account as reward account
+        if (rewardAccount.trim() !== '' && rewardAccount.trim() === account) {
+            setRewardAccountError('You entered your own account as the reward account. To receive rewards to your own account, please leave this field blank.');
+            setProgress(false);
+            return;
+        }
+
         try {
             const posted = await HiveService.updateValidator(
                 {
@@ -102,41 +112,61 @@ function RegisterCard({ account, registered }: { account: string; registered: ()
                             <Input
                                 size="lg"
                                 label="API URL"
-                                placeholder="URL that your node will be accessible from (not required). Not setting this can discourage users from voting for your node."
                                 value={apiUrl}
                                 disabled={progress}
                                 onChange={(e) => setApiUrl(e.target.value.trim())}
                             />
+
                         </div>
                         <div>
                             <Input
                                 size="lg"
                                 label="Post URL"
-                                placeholder="PeakD post describing why users should vote for your node (not required). Not setting this can discourage users from voting for your node."
                                 value={postUrl}
                                 disabled={progress}
                                 onChange={(e) => setPostUrl(e.target.value.trim())}
                             />
+
                         </div>
                         <div>
                             <Input
                                 size="lg"
                                 label="Reward Account"
-                                placeholder="The accounts that your nodes rewards will be sent to. If not set, they will go to the nodes account."
                                 value={rewardAccount}
                                 disabled={progress}
-                                onChange={(e) => setRewardAccount(e.target.value.trim())}
+                                onChange={(e) => {
+                                    setRewardAccount(e.target.value.trim());
+                                    setRewardAccountError('');
+                                }}
+                                error={!!rewardAccountError}
                             />
+
+                            {rewardAccountError && (
+                                <Typography variant="paragraph" color="red" className="mt-1 text-sm font-normal">
+                                    {rewardAccountError}
+                                </Typography>
+                            )}
                         </div>
                     </form>
                 </CardBody>
-                <CardFooter>
+                <CardFooter className="pt-0">
+                    <div className="flex flex-col gap-2">
+                        <Typography variant="paragraph" className="text-sm font-normal">
+                            API URL(not required): URL that your node will be accessible from. Not setting this can discourage users from voting for your node.
+                        </Typography>
+                        <Typography variant="paragraph" className="text-sm font-normal">
+                            Post URL(not required): PeakD post describing why users should vote for your node. Not setting this can discourage users from voting for your node.
+                        </Typography>
+                        <Typography variant="paragraph" className="text-sm font-normal">
+                            Reward Account(not required): Leave blank to receive rewards to your own validator account. Set only if you want rewards sent to a different account.
+                        </Typography>
+                    </div>
                     {error && (
-                        <Typography variant="paragraph" color="red" className="mb-2 text-center">
+                        <Typography variant="paragraph" color="red" className="mb-2 text-center text-sm font-normal">
                             {error}
                         </Typography>
                     )}
-                    <div className="flex items-center justify-end">
+                    <div className="flex items-center justify-end mt-4">
                         <Button className="flex flex-row items-center" variant="filled" disabled={progress} onClick={register}>
                             {progress && <Spinner className="me-3 text-sm" />}
                             Register
@@ -154,11 +184,21 @@ function ManageCard({ account, validator, reloadValidator }: { account: string; 
     const [apiUrl, setApiUrl] = useState<string>(validator.api_url ?? '');
     const [rewardAccount, setRewardAccount] = useState<string>(validator.reward_account ?? '');
     const [error, setError] = useState('');
+    const [rewardAccountError, setRewardAccountError] = useState('');
     const [progress, setProgress] = useState(false);
 
     const update = async () => {
         setProgress(true);
         setError('');
+        setRewardAccountError('');
+        
+        // Prevent user from setting their own account as reward account
+        if (rewardAccount.trim() !== '' && rewardAccount.trim() === account) {
+            setRewardAccountError('You entered your own account as the reward account. To receive rewards to your own account, please leave this field blank.');
+            setProgress(false);
+            return;
+        }
+
         try {
             const broadcastResult = await HiveService.updateValidator(
                 {
@@ -211,7 +251,7 @@ function ManageCard({ account, validator, reloadValidator }: { account: string; 
                         <Typography variant="h5" color="blue-gray" className="mb-2">
                             Manage Validator Node - {account}
                         </Typography>
-                        <form className="mt-8 flex flex-col gap-4">
+                        <form className="mt-4 flex flex-col gap-4">
                             <div className="-mx-3">
                                 <Checkbox checked={isActive} onChange={(e) => setIsActive(e.target.checked)} label="Active" disabled={progress} />
                             </div>
@@ -219,46 +259,67 @@ function ManageCard({ account, validator, reloadValidator }: { account: string; 
                                 <Input
                                     size="lg"
                                     label="API URL"
-                                    placeholder="URL that your node will be accessible from (not required). Not setting this can discourage users from voting for your node."
                                     value={apiUrl}
                                     disabled={progress}
                                     onChange={(e) => setApiUrl(e.target.value.trim())}
                                 />
+
                             </div>
                             <div>
                                 <Input
                                     size="lg"
                                     label="Post URL"
-                                    placeholder="PeakD post describing why users should vote for your node (not required). Not setting this can discourage users from voting for your node."
                                     value={postUrl}
                                     disabled={progress}
                                     onChange={(e) => setPostUrl(e.target.value.trim())}
                                 />
+
                             </div>
                             <div>
                                 <Input
                                     size="lg"
                                     label="Reward Account"
-                                    placeholder="The accounts that your nodes rewards will be sent to. If not set, they will go to the nodes account."
                                     value={rewardAccount}
                                     disabled={progress}
-                                    onChange={(e) => setRewardAccount(e.target.value.trim())}
+                                    onChange={(e) => {
+                                        setRewardAccount(e.target.value.trim());
+                                        setRewardAccountError('');
+                                    }}
+                                    error={!!rewardAccountError}
                                 />
-                            </div>{' '}
+
+                                {rewardAccountError && (
+                                    <Typography variant="paragraph" color="red" className="mt-1 text-sm font-normal">
+                                        {rewardAccountError}
+                                    </Typography>
+                                )}
+                            </div>
+
+                        </form>
+                    </CardBody>
+                    <CardFooter className="pt-0">
+                        <div className="flex flex-col gap-2">
+                            <Typography variant="paragraph" className="text-sm font-normal">
+                                <b>API URL (optional)</b>: URL that your node will be accessible from. Not setting this can discourage users from voting for your node.
+                            </Typography>
+                            <Typography variant="paragraph" className="text-sm font-normal">
+                                <b>Post URL (optional)</b>: PeakD post describing why users should vote for your node. Not setting this can discourage users from voting for your node.
+                            </Typography>
+                            <Typography variant="paragraph" className="text-sm font-normal">
+                                <b>Reward Account (optional)</b>: Leave blank to receive rewards to your own validator account. Set only if you want rewards sent to a different account.
+                            </Typography>
                             {!isActive && (
-                                <Typography variant="paragraph" color="red">
+                                <Typography variant="paragraph" color="red" className="text-sm font-normal">
                                     You will not be able to validate blocks and receive rewards if your node is inactive.
                                 </Typography>
                             )}
-                        </form>
-                    </CardBody>
-                    <CardFooter>
+                        </div>
                         {error && (
-                            <Typography variant="paragraph" color="red" className="mb-2 text-center">
+                            <Typography variant="paragraph" color="red" className="mb-2 text-center text-sm font-normal">
                                 {error}
                             </Typography>
                         )}
-                        <div className="flex items-center justify-end">
+                        <div className="flex items-center justify-end mt-4">
                             <Button className="flex flex-row items-center" variant="filled" disabled={progress} onClick={update}>
                                 {progress && <Spinner className="me-3 text-sm" />}
                                 Update


### PR DESCRIPTION
This improves the user experience for the manage validator node page's settings. Users keep entering their own account name as the reward account and get an error (issue https://github.com/TheSPSDAO/SPS-Validator/issues/56).

#### Changes
- Added validation to detect when users enter their own account as the reward account.
- Added descriptions outside each form and labeled them as optional. Make sure the font style matches the others.

#### Testing
- An error message appears when a user enters their own account name.
- Form submission works correctly.

#### Screenshots
When it's active and entering your own account and click Update

![2025-03-25-16-08-31](https://github.com/user-attachments/assets/2a54d2a3-2430-4563-aa7d-0022bc18e106)

When it's inactive and there's nothing on the forms

![2025-03-25-16-10-44](https://github.com/user-attachments/assets/48c93e29-e02a-455b-a3b0-9e5e9f8f6b09)
