### PR TITLE
Auto update Recent Blocks on Block Explorer page

### DIFF
--- a/apps/sps-validator-ui/src/app/hooks/Promise.ts
+++ b/apps/sps-validator-ui/src/app/hooks/Promise.ts
@@ -43,10 +43,17 @@ export function usePromise<T>(fn: () => MaybeCancelablePromise<T>, deps?: Depend
 export function usePromiseRefresh<T>(fn: () => MaybeCancelablePromise<T>, interval: number, deps?: DependencyList): [T | null, boolean, Error | null, () => void] {
     const [result, loading, error, reload] = usePromise(fn, deps);
     useEffect(() => {
-        const id = setInterval(() => {
-            reload();
-        }, interval);
-        return () => clearInterval(id);
-    }, [interval]);
+        let id: NodeJS.Timeout | undefined;
+        if (interval > 0) {
+            id = setInterval(() => {
+                reload();
+            }, interval);
+        }
+        return () => {
+            if (id) {
+                clearInterval(id);
+            }
+        };
+    }, [interval, reload]); // Added reload to dependency array
     return [result, loading, error, reload];
 }

--- a/apps/sps-validator-ui/src/app/hooks/Promise.ts
+++ b/apps/sps-validator-ui/src/app/hooks/Promise.ts
@@ -54,6 +54,6 @@ export function usePromiseRefresh<T>(fn: () => MaybeCancelablePromise<T>, interv
                 clearInterval(id);
             }
         };
-    }, [interval, reload]); // Added reload to dependency array
+    }, [interval, reload]);
     return [result, loading, error, reload];
 }

--- a/apps/sps-validator-ui/src/app/pages/block-explorer/BlockExplorer.tsx
+++ b/apps/sps-validator-ui/src/app/pages/block-explorer/BlockExplorer.tsx
@@ -10,15 +10,15 @@ import { listItemClickHandler } from './utils';
 export function BlockList({ className }: { className?: string }) {
     const [blockOffset] = React.useState<number | undefined>(undefined);
     const [limit] = React.useState(15);
-    const [autoRefresh, setAutoRefresh] = React.useState(true); // Added state for auto-refresh
+    const [autoRefresh, setAutoRefresh] = React.useState(true);
     const nav = useNavigate();
 
-    const refreshInterval = autoRefresh ? 3000 : 0; // Calculate interval based on state
+    const refreshInterval = autoRefresh ? 3000 : 0;
 
     const [blocks, isBlocksLoading, error] = usePromiseRefresh<Block[]>(() => DefaultService.getBlocks(limit, blockOffset), refreshInterval, [limit, blockOffset]); // Use calculated interval
 
     if (error) {
-        return <Typography color="red">Error loading blocks: {error.message}</Typography>; // Added error display
+        return <Typography color="red">Error loading blocks: {error.message}</Typography>;
     }
     if (isBlocksLoading && !blocks) {
         return <Spinner />;
@@ -30,16 +30,11 @@ export function BlockList({ className }: { className?: string }) {
     return (
         <Card className={className}>
             <CardBody>
-                <div className="flex justify-between items-center mb-2"> {/* Container for title and checkbox */}
+                <div className="flex justify-between items-center mb-2">
                     <Typography variant="h5" color="blue-gray">
                         Recent Blocks
                     </Typography>
-                    <Checkbox
-                        label="Auto-refresh"
-                        checked={autoRefresh}
-                        onChange={(e) => setAutoRefresh(e.target.checked)}
-                        crossOrigin={undefined} // Required prop for Material Tailwind v2+
-                    />
+                    <Checkbox label="Auto-refresh" checked={autoRefresh} onChange={(e) => setAutoRefresh(e.target.checked)} />
                 </div>
                 <List className="p-0 mt-4">
                     {blocks.map((block, i) => (

--- a/apps/sps-validator-ui/src/app/pages/block-explorer/BlockExplorer.tsx
+++ b/apps/sps-validator-ui/src/app/pages/block-explorer/BlockExplorer.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, List, ListItem, Spinner, Tooltip, Typography } from '@material-tailwind/react';
+import { Card, CardBody, List, ListItem, Spinner, Tooltip, Typography, Checkbox } from '@material-tailwind/react'; // Added Checkbox
 import { DefaultService, Block } from '../../services/openapi';
 import React from 'react';
 import { usePromiseRefresh } from '../../hooks/Promise';
@@ -10,10 +10,16 @@ import { listItemClickHandler } from './utils';
 export function BlockList({ className }: { className?: string }) {
     const [blockOffset] = React.useState<number | undefined>(undefined);
     const [limit] = React.useState(15);
+    const [autoRefresh, setAutoRefresh] = React.useState(true); // Added state for auto-refresh
     const nav = useNavigate();
 
-    const [blocks, isBlocksLoading, error] = usePromiseRefresh<Block[]>(() => DefaultService.getBlocks(limit, blockOffset), 3000, [limit, blockOffset]);
+    const refreshInterval = autoRefresh ? 3000 : 0; // Calculate interval based on state
 
+    const [blocks, isBlocksLoading, error] = usePromiseRefresh<Block[]>(() => DefaultService.getBlocks(limit, blockOffset), refreshInterval, [limit, blockOffset]); // Use calculated interval
+
+    if (error) {
+        return <Typography color="red">Error loading blocks: {error.message}</Typography>; // Added error display
+    }
     if (isBlocksLoading && !blocks) {
         return <Spinner />;
     }
@@ -24,9 +30,17 @@ export function BlockList({ className }: { className?: string }) {
     return (
         <Card className={className}>
             <CardBody>
-                <Typography variant="h5" color="blue-gray" className="mb-2">
-                    Recent Blocks
-                </Typography>
+                <div className="flex justify-between items-center mb-2"> {/* Container for title and checkbox */}
+                    <Typography variant="h5" color="blue-gray">
+                        Recent Blocks
+                    </Typography>
+                    <Checkbox
+                        label="Auto-refresh"
+                        checked={autoRefresh}
+                        onChange={(e) => setAutoRefresh(e.target.checked)}
+                        crossOrigin={undefined} // Required prop for Material Tailwind v2+
+                    />
+                </div>
                 <List className="p-0 mt-4">
                     {blocks.map((block, i) => (
                         <React.Fragment key={block.block_num}>


### PR DESCRIPTION
Currently, the Recent Blocks list on the Block Explorer page requires a manual refresh to display newly generated blocks.

With this update, the Recent Blocks list now updates automatically every 3 seconds, providing a more dynamic view of block generation activity.

Before

![2025-03-31-12-56-14](https://github.com/user-attachments/assets/5a6c0e3c-f557-43f0-a904-e55a64cfc217)

After

![2025-03-31-12-57-26](https://github.com/user-attachments/assets/4b18e5e8-17b2-4dde-b219-af81daa13a09)
