### PR TITLE
Add command to run.sh to repartition database

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ You can take snapshots locally to take backups, and restore them without uploadi
 - `./run.sh replay`: rebuilds your node from the snapshot. :warning: **This will irrevocably destroy all local data, including blocks that have already been locally validated**: Be very careful here!
 - `./run.sh destroy`: completely removes the database, validator, and ui. :warning: **This will irrevocably destroy all local data, including blocks that have already been locally validated**: Be very careful here!
 - `./run.sh status`: checks your validator node status and registration status (running/active/inactive)
-- `./run.sh repartition_tables`: Rhelper command to repartition the partitioned database tables. only needed if upgrading a database from before v1.1.1 or if restoring a snapshot from before v1.1.1.
-- `./run.sh psql [args]`: runs psql with the given args. e.g. run.sh psql -c 'SELECT * FROM blocks
+- `./run.sh repartition_tables`: helper command to repartition the partitioned database tables. only needed if upgrading a database from before v1.1.1 or if restoring a snapshot from before v1.1.1.
+- `./run.sh psql [args]`: runs psql against the validator database with the given args. e.g. `run.sh psql -c "SELECT * FROM blocks LIMIT 10"`
 
 ## Updating your node
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,13 @@ You can take snapshots locally to take backups, and restore them without uploadi
 - `./run.sh start all`: starts either the database, validator, and ui
 - `./run.sh restart`: helpful wrapper around `./run.sh stop` and `./run.sh start`
 - `./run.sh logs`: trails the last 30 lines of logs
-- `./run.sh snapshot`: stops the validator and creates a snapshot of the database. this snapshot can be uploaded and used to restore another validator.
-- `./run.sh rebuild_service <validator | pg | ui>`: force rebuilds a service to apply new environment variables.
+- `./run.sh snapshot`: stops the validator and creates a snapshot of the database. this snapshot can be uploaded and used to restore another validator
+- `./run.sh rebuild_service <validator | pg | ui>`: force rebuilds a service to apply new environment variables
 - `./run.sh replay`: rebuilds your node from the snapshot. :warning: **This will irrevocably destroy all local data, including blocks that have already been locally validated**: Be very careful here!
 - `./run.sh destroy`: completely removes the database, validator, and ui. :warning: **This will irrevocably destroy all local data, including blocks that have already been locally validated**: Be very careful here!
 - `./run.sh status`: checks your validator node status and registration status (running/active/inactive)
+- `./run.sh repartition_tables`: Rhelper command to repartition the partitioned database tables. only needed if upgrading a database from before v1.1.1 or if restoring a snapshot from before v1.1.1.
+- `./run.sh psql [args]`: runs psql with the given args. e.g. run.sh psql -c 'SELECT * FROM blocks
 
 ## Updating your node
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,4 +6,4 @@ When master branch is ready to be released:
 - Create a new branch named `release-{version}` from the previous release branch. 
 - Create a PR from master to the new branch and review the changes. The tests will run.
 - Create a new release on the new branch, the tag should match the `VERSION=` variable you set (`v{version}`)
-- Force create/push a new tag, `vlatest`, pointed to the new branch.
+- Force create/push a new tag, `vlatest`, pointed to the new branch (`git tag -f vlatest v{version}^{}`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       APP_USER: ${APP_USER:-validator}
       APP_DATABASE: ${APP_DATABASE:-validator}
       APP_SCHEMA: ${APP_SCHEMA:-public}
-      DB_BLOCK_RETENTION: ${DB_BLOCK_RETENTION}
+      DB_BLOCK_RETENTION: ${DB_BLOCK_RETENTION:-}
 
   ui:
     build:

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,8 @@ COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
 
 APP_SCHEMA=${APP_SCHEMA:-public}
 APP_DATABASE=${APP_DATABASE:-validator}
-POSTGRES_USER=${POSTGRES_USER:-postgres}
+APP_USER=${APP_USER:-validator}
+APP_PASSWORD=${APP_PASSWORD:-validator}
 
 if [[ -f ".env" ]]; then
     # shellcheck source=/dev/null
@@ -41,11 +42,11 @@ docker_compose() {
 }
 
 run_psql() {
-    docker_compose exec pg psql -U "$POSTGRES_USER" -h 127.0.0.1 -d "$APP_DATABASE" "$@"
+    docker_compose exec pg psql -U "$APP_USER" -h 127.0.0.1 -d "$APP_DATABASE" "$@"
 }
 
 run_psql_quiet() {
-    docker_compose exec -e PGOPTIONS="--client-min-messages=warning" pg psql -U "$POSTGRES_USER" -h 127.0.0.1 -d "$APP_DATABASE" "$@"
+    docker_compose exec -e PGOPTIONS="--client-min-messages=warning" pg psql -U "$APP_USER" -h 127.0.0.1 -d "$APP_DATABASE" "$@"
 }
 
 snapshot() {
@@ -65,13 +66,13 @@ snapshot() {
 
     # dump the snapshot to a file
     echo "Dumping snapshot to file"
-    docker_compose exec -e PGPASSWORD="$POSTGRES_PASSWORD" pg pg_dump \
+    docker_compose exec -e PGPASSWORD="$APP_PASSWORD" pg pg_dump \
         --no-owner --no-acl \
         --no-comments --no-publications --no-security-labels \
         --schema snapshot \
         --no-subscriptions --no-tablespaces --data-only \
         --host "127.0.0.1" \
-        --username "$POSTGRES_USER" \
+        --username "$APP_USER" \
         "${APP_DATABASE}" > snapshot.sql
 
     # get the latest change from the sqitch.changes table with psql

--- a/run.sh
+++ b/run.sh
@@ -97,6 +97,15 @@ snapshot() {
 }
 
 repartition_tables() {
+    # confirm they want to do this
+    echo "Repartioning only has to be done if your database existed before version v1.1.1, or if you have restored a snapshot from before that version."
+    echo "Repartitioning will take a while and will lock the tables. It's not required, but you should stop your validator to be safe."
+    read -p "Are you sure you want to repartition the tables? (y/n)" -n 1 -r
+    echo    # (optional) move to a new line
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborting repartition"
+        exit
+    fi
     repartition_table "blocks"
     repartition_table "validator_transactions"
     repartition_table "validator_transaction_players"

--- a/run.sh
+++ b/run.sh
@@ -7,11 +7,6 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 SQITCH_DIR="$SCRIPT_DIR/sqitch"
 COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
 
-APP_SCHEMA=${APP_SCHEMA:-public}
-APP_DATABASE=${APP_DATABASE:-validator}
-APP_USER=${APP_USER:-validator}
-APP_PASSWORD=${APP_PASSWORD:-validator}
-
 if [[ -f ".env" ]]; then
     # shellcheck source=/dev/null
     source .env
@@ -35,6 +30,11 @@ if [[ ! $SNAPSHOT_URL ]]; then
     echo "SNAPSHOT_URL not defined in the .env file"
     exit
 fi
+
+APP_SCHEMA=${APP_SCHEMA:-public}
+APP_DATABASE=${APP_DATABASE:-validator}
+APP_USER=${APP_USER:-validator}
+APP_PASSWORD=${APP_PASSWORD:-validator}
 
 docker_compose() {
     # not really useful anymore but leaving it in case it is needed

--- a/run.sh
+++ b/run.sh
@@ -41,11 +41,11 @@ docker_compose() {
 }
 
 run_psql() {
-    docker_compose exec pg psql -U $POSTGRES_USER -h 127.0.0.1 -d "$APP_DATABASE" "$@"
+    docker_compose exec pg psql -U "$POSTGRES_USER" -h 127.0.0.1 -d "$APP_DATABASE" "$@"
 }
 
 run_psql_quiet() {
-    docker_compose exec -e PGOPTIONS="--client-min-messages=warning" pg psql -U $POSTGRES_USER -h 127.0.0.1 -d "$APP_DATABASE" "$@"
+    docker_compose exec -e PGOPTIONS="--client-min-messages=warning" pg psql -U "$POSTGRES_USER" -h 127.0.0.1 -d "$APP_DATABASE" "$@"
 }
 
 snapshot() {

--- a/sqitch/deploy/post-snapshot-restore-partition-prep.sql
+++ b/sqitch/deploy/post-snapshot-restore-partition-prep.sql
@@ -2,6 +2,11 @@
 
 BEGIN;
 
+-- fix a previous issue with the partman retention policy when you have no retention set
+UPDATE
+  partman.part_config
+SET
+  retention=NULLIF(retention, '')::text;
 
 CREATE OR REPLACE FUNCTION snapshot.post_snapshot_restore(p_data_schema text DEFAULT :'APP_SCHEMA'::text)
     RETURNS void

--- a/sqitch/deploy/post-snapshot-restore-partition-prep.sql
+++ b/sqitch/deploy/post-snapshot-restore-partition-prep.sql
@@ -1,0 +1,101 @@
+-- Deploy splinterlands-validator:post-snapshot-restore-function to pg
+
+BEGIN;
+
+
+CREATE OR REPLACE FUNCTION snapshot.post_snapshot_restore(p_data_schema text DEFAULT :'APP_SCHEMA'::text)
+    RETURNS void
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS $BODY$
+DECLARE
+    v_min_block_number    bigint;
+    v_max_block_number    bigint;
+    v_block_partition_ids bigint[];
+BEGIN
+
+	PERFORM set_config('search_path', regexp_replace(p_data_schema ||', public', '[^\w ,]', '', 'g'), true);
+
+	RAISE NOTICE 'Data source schema: %', p_data_schema;
+
+    -- special handling for partitioned tables
+    SELECT MIN(block_num) INTO v_min_block_number FROM snapshot.blocks;
+    IF v_min_block_number IS NULL THEN
+        v_min_block_number := 0;
+    END IF;
+
+    SELECT MAX(block_num) INTO v_max_block_number FROM snapshot.blocks;
+    IF v_max_block_number IS NULL THEN
+        v_max_block_number := 432000 * 5;
+    END IF;
+
+    SELECT
+        array(
+            SELECT generate_series(
+                v_min_block_number,
+                v_max_block_number,
+                432000
+            )
+        )
+    INTO v_block_partition_ids;
+
+    -- create the new partitions first
+    PERFORM partman.create_partition_id(p_data_schema || '.blocks', v_block_partition_ids);
+    PERFORM partman.create_partition_id(p_data_schema || '.validator_transactions', v_block_partition_ids);
+    PERFORM partman.create_partition_id(p_data_schema || '.validator_transaction_players', v_block_partition_ids);
+
+    -- run maintenance to clean up any old partitions and add new ones.
+    -- note: if the node is an archive node, we will have some empty partitions at block 0. this shouldnt cause any issues but
+    -- it'd be nice if we could get rid of them in the future
+    PERFORM partman.run_maintenance(p_analyze := TRUE, p_jobmon := FALSE);
+
+    INSERT INTO blocks SELECT * FROM snapshot.blocks;
+    INSERT INTO validator_transactions SELECT * FROM snapshot.validator_transactions;
+    INSERT INTO validator_transaction_players SELECT * FROM snapshot.validator_transaction_players;
+
+    -- partman will premake the remaining future partitions and drop any old ones
+    PERFORM partman.run_maintenance(p_analyze := TRUE, p_jobmon := FALSE);
+
+    INSERT INTO active_delegations SELECT * FROM snapshot.active_delegations;
+    INSERT INTO balance_history SELECT * FROM snapshot.balance_history;
+    INSERT INTO balances SELECT * FROM snapshot.balances;
+    INSERT INTO config SELECT * FROM snapshot.config;
+    INSERT INTO hive_accounts SELECT * FROM snapshot.hive_accounts;
+    INSERT INTO price_history SELECT * FROM snapshot.price_history;
+    INSERT INTO staking_pool_reward_debt SELECT * FROM snapshot.staking_pool_reward_debt;
+    INSERT INTO validator_votes SELECT * FROM snapshot.validator_votes;
+    INSERT INTO validator_vote_history SELECT * FROM snapshot.validator_vote_history;
+    INSERT INTO validators SELECT * FROM snapshot.validators;
+    INSERT INTO token_unstaking SELECT * FROM snapshot.token_unstaking;
+    INSERT INTO validator_check_in SELECT * FROM snapshot.validator_check_in;
+
+    -- special handling for serial keyed tables
+    INSERT INTO promise SELECT * FROM snapshot.promise;
+    INSERT INTO promise_history SELECT * FROM snapshot.promise_history;
+    -- set the sequence values for the serial columns
+    PERFORM setval(p_data_schema || '.promise_id_seq', (SELECT MAX(id) FROM promise), true);
+    PERFORM setval(p_data_schema || '.promise_history_id_seq', (SELECT MAX(id) FROM promise_history), true);
+
+    TRUNCATE TABLE snapshot.balances;
+    TRUNCATE TABLE snapshot.balance_history;
+    TRUNCATE TABLE snapshot.hive_accounts;
+    TRUNCATE TABLE snapshot.staking_pool_reward_debt;
+    TRUNCATE TABLE snapshot.validator_votes;
+    TRUNCATE TABLE snapshot.validator_vote_history;
+    TRUNCATE TABLE snapshot.validators;
+    TRUNCATE TABLE snapshot.blocks;
+    TRUNCATE TABLE snapshot.validator_transactions;
+    TRUNCATE TABLE snapshot.validator_transaction_players;
+    TRUNCATE TABLE snapshot.token_unstaking;
+    TRUNCATE TABLE snapshot.price_history;
+    TRUNCATE TABLE snapshot.config;
+    TRUNCATE TABLE snapshot.active_delegations;
+    TRUNCATE TABLE snapshot.validator_check_in;
+    TRUNCATE TABLE snapshot.promise;
+    TRUNCATE TABLE snapshot.promise_history;
+
+END;
+$BODY$;
+
+COMMIT;

--- a/sqitch/revert/post-snapshot-restore-partition-prep.sql
+++ b/sqitch/revert/post-snapshot-restore-partition-prep.sql
@@ -1,0 +1,62 @@
+-- Deploy splinterlands-validator:post-snapshot-restore-function to pg
+
+BEGIN;
+
+
+CREATE OR REPLACE FUNCTION snapshot.post_snapshot_restore(p_data_schema text DEFAULT :'APP_SCHEMA'::text)
+    RETURNS void
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS $BODY$
+BEGIN
+
+	PERFORM set_config('search_path', regexp_replace(p_data_schema ||', public', '[^\w ,]', '', 'g'), true);
+
+	RAISE NOTICE 'Data source schema: %', p_data_schema;
+
+    INSERT INTO active_delegations SELECT * FROM snapshot.active_delegations;
+    INSERT INTO balance_history SELECT * FROM snapshot.balance_history;
+    INSERT INTO balances SELECT * FROM snapshot.balances;
+    INSERT INTO config SELECT * FROM snapshot.config;
+    INSERT INTO hive_accounts SELECT * FROM snapshot.hive_accounts;
+    INSERT INTO price_history SELECT * FROM snapshot.price_history;
+    INSERT INTO staking_pool_reward_debt SELECT * FROM snapshot.staking_pool_reward_debt;
+    INSERT INTO validator_votes SELECT * FROM snapshot.validator_votes;
+    INSERT INTO validator_vote_history SELECT * FROM snapshot.validator_vote_history;
+    INSERT INTO validators SELECT * FROM snapshot.validators;
+    INSERT INTO blocks SELECT * FROM snapshot.blocks;
+    INSERT INTO validator_transactions SELECT * FROM snapshot.validator_transactions;
+    INSERT INTO validator_transaction_players SELECT * FROM snapshot.validator_transaction_players;
+    INSERT INTO token_unstaking SELECT * FROM snapshot.token_unstaking;
+    INSERT INTO validator_check_in SELECT * FROM snapshot.validator_check_in;
+
+    -- special handling for serial keyed tables
+    INSERT INTO promise SELECT * FROM snapshot.promise;
+    INSERT INTO promise_history SELECT * FROM snapshot.promise_history;
+    -- set the sequence values for the serial columns
+    PERFORM setval(p_data_schema || '.promise_id_seq', (SELECT MAX(id) FROM promise), true);
+    PERFORM setval(p_data_schema || '.promise_history_id_seq', (SELECT MAX(id) FROM promise_history), true);
+
+    TRUNCATE TABLE snapshot.balances;
+    TRUNCATE TABLE snapshot.balance_history;
+    TRUNCATE TABLE snapshot.hive_accounts;
+    TRUNCATE TABLE snapshot.staking_pool_reward_debt;
+    TRUNCATE TABLE snapshot.validator_votes;
+    TRUNCATE TABLE snapshot.validator_vote_history;
+    TRUNCATE TABLE snapshot.validators;
+    TRUNCATE TABLE snapshot.blocks;
+    TRUNCATE TABLE snapshot.validator_transactions;
+    TRUNCATE TABLE snapshot.validator_transaction_players;
+    TRUNCATE TABLE snapshot.token_unstaking;
+    TRUNCATE TABLE snapshot.price_history;
+    TRUNCATE TABLE snapshot.config;
+    TRUNCATE TABLE snapshot.active_delegations;
+    TRUNCATE TABLE snapshot.validator_check_in;
+    TRUNCATE TABLE snapshot.promise;
+    TRUNCATE TABLE snapshot.promise_history;
+
+END;
+$BODY$;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -18,3 +18,4 @@ validator_api_url 2025-02-24T20:07:55Z stephen <stephen@LAPTOP-N4OOE985> # Add a
 transaction_players_perf 2025-02-25T20:07:13Z stephen <stephen@LAPTOP-N4OOE985> # Update transaction players schema for better performance
 partitions 2025-02-25T20:31:18Z stephen <stephen@LAPTOP-N4OOE985> # Add partitioning to large tables
 snapshot-function-v2 2025-02-26T01:44:21Z stephen <stephen@LAPTOP-N4OOE985> # add new transaction players columns to freshsnapshot and rework archive logic
+post-snapshot-restore-partition-prep 2025-04-15T18:53:29Z stephen <stephen@LAPTOP-N4OOE985> # Prep partitioned tables when restoring snapshots

--- a/sqitch/verify/post-snapshot-restore-partition-prep.sql
+++ b/sqitch/verify/post-snapshot-restore-partition-prep.sql
@@ -1,0 +1,7 @@
+-- Verify splinterlands-validator:post-snapshot-restore-partition-prep on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
Fixes the partitions when a new snapshot is restored. The partitions currently only work when they're created on a snapshot that was taken before partitioning existed. 

This PR adds a new command to run.sh to fix existing databases, `./run.sh repartition_tables`. Everyone should run this command (even archive nodes), because it will correctly partition out the data and make queries for more recent data faster.

This PR also updates the snapshot restore process to prepare the partitioned tables before we populate them. So any new nodes created after this version of the validator will not have to run the command.