### PR TITLE
Additions to supply endpoints

### DIFF
--- a/apps/sps-validator/src/sps/convict-config.ts
+++ b/apps/sps-validator/src/sps/convict-config.ts
@@ -291,6 +291,12 @@ const schema = {
         default: 'sps.dao.reserves',
         env: 'DAO_RESERVE_ACCOUNT',
     },
+    dao_delegation_account: {
+        doc: 'SPS dao delegation account',
+        nullable: false,
+        default: 'spsdaodelegations ',
+        env: 'DAO_DELEGATIONS_ACCOUNT',
+    },
     sl_hive_account: {
         doc: 'SPS sl-hive account',
         nullable: false,
@@ -300,13 +306,13 @@ const schema = {
     terablock_bsc_account: {
         doc: 'SPS terablock bsc account',
         nullable: false,
-        default: 'terablock-bsc',
+        default: 'zkcn-bsc',
         env: 'TERABLOCK_BSC_ACCOUNT',
     },
     terablock_eth_account: {
         doc: 'SPS terablock eth account',
         nullable: false,
-        default: 'terablock-eth',
+        default: 'zkcn-eth',
         env: 'TERABLOCK_ETH_ACCOUNT',
     },
     reward_pool_accounts: {

--- a/apps/sps-validator/src/sps/convict-config.ts
+++ b/apps/sps-validator/src/sps/convict-config.ts
@@ -294,8 +294,8 @@ const schema = {
     dao_delegation_account: {
         doc: 'SPS dao delegation account',
         nullable: false,
-        default: 'spsdaodelegations ',
-        env: 'DAO_DELEGATIONS_ACCOUNT',
+        default: 'spsdaodelegation',
+        env: 'DAO_DELEGATION_ACCOUNT',
     },
     sl_hive_account: {
         doc: 'SPS sl-hive account',

--- a/apps/sps-validator/src/sps/entities/tokens/balance.ts
+++ b/apps/sps-validator/src/sps/entities/tokens/balance.ts
@@ -266,13 +266,20 @@ export class SpsBalanceRepository extends BalanceRepository {
 
                     this.supplyOpts.dao_account,
                     this.supplyOpts.dao_reserve_account,
+                    this.supplyOpts.dao_delegation_account,
                     this.supplyOpts.sl_hive_account,
                     this.supplyOpts.terablock_bsc_account,
                     this.supplyOpts.terablock_eth_account,
 
                     ...this.supplyOpts.reward_pool_accounts,
                 ],
-                [TOKENS.SPSP]: [this.supplyOpts.staking_account, this.supplyOpts.dao_account, this.supplyOpts.terablock_bsc_account, this.supplyOpts.terablock_eth_account],
+                [TOKENS.SPSP]: [
+                    this.supplyOpts.staking_account,
+                    this.supplyOpts.dao_account,
+                    this.supplyOpts.dao_delegation_account,
+                    this.supplyOpts.terablock_bsc_account,
+                    this.supplyOpts.terablock_eth_account,
+                ],
             },
             trx,
         );
@@ -388,8 +395,8 @@ export class SpsBalanceRepository extends BalanceRepository {
         const pendingImmediateUnstake = parseFloat(pendingImmediateUnstakeRows.rows[0]?.pending_unstake ?? 0);
 
         return {
-            pending_unstake: pendingUnstake,
-            pending_immediate_unstake: pendingImmediateUnstake,
+            pending_unstake: +pendingUnstake.toFixed(3),
+            pending_immediate_unstake: +pendingImmediateUnstake.toFixed(3),
         };
     }
 


### PR DESCRIPTION
Updates the terablock accounts to the new ones, adds the dao delegation account, adds a total for reserved / offchain balances, and adds a token unstaking summary section.