### PR TITLE
Add transitions endpoint and upcoming transitions to the home page

### DIFF
--- a/apps/sps-validator-ui/openapi.yaml
+++ b/apps/sps-validator-ui/openapi.yaml
@@ -587,6 +587,21 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/BalancesCount"
 
+    /extensions/transitions:
+        get:
+            tags:
+                - Default
+            summary: Gets the upcoming validator transitions
+            description: Returns the list of upcoming validator transitions
+            operationId: getTransitions
+            responses:
+                200:
+                    description: Successful operation
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/TransitionStatuses"
+
 components:
     schemas:
         Account:
@@ -841,6 +856,36 @@ components:
                     type: string
                 index:
                     type: integer
+
+        TransitionStatuses:
+            type: object
+            properties:
+                block_num:
+                    type: number
+                transition_points:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/TransitionStatus"
+
+        TransitionStatus:
+            type: object
+            required:
+                - transition
+                - block_num
+                - blocks_until
+                - transitioned
+                - description
+            properties:
+                transition:
+                    type: string
+                block_num:
+                    type: number
+                blocks_until:
+                    type: number
+                transitioned:
+                    type: boolean
+                description:
+                    type: string
 
         TokenSupply:
             type: object

--- a/apps/sps-validator-ui/src/app/pages/Home.tsx
+++ b/apps/sps-validator-ui/src/app/pages/Home.tsx
@@ -65,12 +65,12 @@ const MetricsCard = () => {
     );
 };
 
-export type TopValidatorsTableProps = {
+type TopValidatorsTableProps = {
     limit?: number;
     active?: boolean;
 };
 
-export function TopValidatorsTable(props: TopValidatorsTableProps) {
+function TopValidatorsTable(props: TopValidatorsTableProps) {
     const [result, isLoading] = usePromise(() => DefaultService.getValidators(props.limit, undefined, undefined, props.active), [props.limit]);
     if (isLoading) {
         return <Spinner className="w-full" />;
@@ -131,12 +131,12 @@ export function TopValidatorsTable(props: TopValidatorsTableProps) {
     );
 }
 
-export type TopSpsHoldersTableProps = {
+type TopSpsHoldersTableProps = {
     limit?: number;
     className?: string;
 };
 
-export function TopSpsHoldersTable(props: TopSpsHoldersTableProps) {
+function TopSpsHoldersTable(props: TopSpsHoldersTableProps) {
     const [balances, isLoading] = usePromise(() => DefaultService.getExtendedBalancesByToken('SPS_TOTAL', props.limit), [props.limit]);
     if (isLoading) {
         return <Spinner className="w-full" />;
@@ -169,6 +169,70 @@ export function TopSpsHoldersTable(props: TopSpsHoldersTableProps) {
     );
 }
 
+function UpcomingTransitionsCard(props: { className?: string }) {
+    const [result, isLoading] = usePromise(() => DefaultService.getTransitions(), []);
+    const transitions = result?.transition_points;
+    if (isLoading || !transitions) {
+        return;
+    }
+
+    const upcomingTransitions = transitions.filter((transition) => !transition.transitioned && transition.blocks_until <= 432000);
+    if (upcomingTransitions.length === 0) {
+        return;
+    }
+
+    return (
+        <Card className={props.className}>
+            <CardBody>
+                <Typography variant="h5" color="blue-gray" className="mb-2">
+                    Upcoming Transitions
+                </Typography>
+                <Typography variant="paragraph" className="mb-2">
+                    Transitions are changes to the SPS validator nodes that are scheduled to occur in the future. They are used to implement new features or changes to the node
+                    software. If you are a validator node operator, you should be aware of these transitions and must be prepared to update your node before they occur.
+                </Typography>
+                <Table className="w-full mt-5 border-2 border-gray-200">
+                    <TableHead>
+                        <TableRow>
+                            <TableColumn>
+                                <Typography color="blue-gray" className="font-normal text-left">
+                                    Transition
+                                </Typography>
+                            </TableColumn>
+                            <TableColumn>
+                                <Typography color="blue-gray" className="font-normal text-left">
+                                    Block Num
+                                </Typography>
+                            </TableColumn>
+                            <TableColumn>
+                                <Typography color="blue-gray" className="font-normal text-left">
+                                    Blocks Until
+                                </Typography>
+                            </TableColumn>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {upcomingTransitions.map((transition) => (
+                            <TableRow key={transition.transition}>
+                                <TableCell>
+                                    <Typography color="blue-gray" className="font-bold">
+                                        {transition.transition}
+                                    </Typography>
+                                    <Typography color="blue-gray" className="text-sm">
+                                        {transition.description}
+                                    </Typography>
+                                </TableCell>
+                                <TableCell>{localeNumber(transition.block_num)}</TableCell>
+                                <TableCell>{localeNumber(transition.blocks_until)}</TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </CardBody>
+        </Card>
+    );
+}
+
 export function Home() {
     return (
         <div className="grid xl:grid-cols-4 gap-6">
@@ -188,6 +252,8 @@ export function Home() {
                         </Typography>
                     </CardBody>
                 </Card>
+
+                <UpcomingTransitionsCard className="col-span-full" />
 
                 <Card className="col-span-full">
                     <CardBody>

--- a/apps/sps-validator-ui/src/app/services/openapi/index.ts
+++ b/apps/sps-validator-ui/src/app/services/openapi/index.ts
@@ -20,6 +20,8 @@ export type { TokenSupply } from './models/TokenSupply';
 export type { TokenTransferTransaction } from './models/TokenTransferTransaction';
 export type { TokenTransferTransactions } from './models/TokenTransferTransactions';
 export type { Transaction } from './models/Transaction';
+export type { TransitionStatus } from './models/TransitionStatus';
+export type { TransitionStatuses } from './models/TransitionStatuses';
 export type { Validator } from './models/Validator';
 export type { ValidatorConfig } from './models/ValidatorConfig';
 export type { Validators } from './models/Validators';

--- a/apps/sps-validator-ui/src/app/services/openapi/models/TransitionStatus.ts
+++ b/apps/sps-validator-ui/src/app/services/openapi/models/TransitionStatus.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type TransitionStatus = {
+    transition: string;
+    block_num: number;
+    blocks_until: number;
+    transitioned: boolean;
+    description: string;
+};
+

--- a/apps/sps-validator-ui/src/app/services/openapi/models/TransitionStatuses.ts
+++ b/apps/sps-validator-ui/src/app/services/openapi/models/TransitionStatuses.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { TransitionStatus } from './TransitionStatus';
+export type TransitionStatuses = {
+    block_num?: number;
+    transition_points?: Array<TransitionStatus>;
+};
+

--- a/apps/sps-validator-ui/src/app/services/openapi/services/DefaultService.ts
+++ b/apps/sps-validator-ui/src/app/services/openapi/services/DefaultService.ts
@@ -12,6 +12,7 @@ import type { Status } from '../models/Status';
 import type { TokenSupply } from '../models/TokenSupply';
 import type { TokenTransferTransactions } from '../models/TokenTransferTransactions';
 import type { Transaction } from '../models/Transaction';
+import type { TransitionStatuses } from '../models/TransitionStatuses';
 import type { Validator } from '../models/Validator';
 import type { ValidatorConfig } from '../models/ValidatorConfig';
 import type { Validators } from '../models/Validators';
@@ -474,6 +475,18 @@ export class DefaultService {
                 'skip': skip,
                 'systemAccounts': systemAccounts,
             },
+        });
+    }
+    /**
+     * Gets the upcoming validator transitions
+     * Returns the list of upcoming validator transitions
+     * @returns TransitionStatuses Successful operation
+     * @throws ApiError
+     */
+    public static getTransitions(): CancelablePromise<TransitionStatuses> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/extensions/transitions',
         });
     }
 }

--- a/apps/sps-validator/src/sps/api/index.ts
+++ b/apps/sps-validator/src/sps/api/index.ts
@@ -19,6 +19,7 @@ import {
 import { utils } from 'splinterlands-dhive-sl';
 import { ManualDisposer } from '../manual-disposable';
 import { registerSpsRoutes } from './sps';
+import { registerTransitionRoutes } from './transition';
 
 // Each Middleware allows requests to read (cache) state from 'the world'. What this means is different for each type of middleware.
 
@@ -126,6 +127,7 @@ export class EnabledApiActivator implements ConditionalApiActivator {
 
         // must come after registerApiRoutes so we have the resolver
         registerSpsRoutes(app);
+        registerTransitionRoutes(app);
 
         return app;
     }

--- a/apps/sps-validator/src/sps/api/transition.ts
+++ b/apps/sps-validator/src/sps/api/transition.ts
@@ -1,0 +1,20 @@
+import { LastBlockCache } from '@steem-monsters/splinterlands-validator';
+import { Router } from 'express';
+import { TransitionManager } from '../features/transition';
+
+export function registerTransitionRoutes(app: Router) {
+    app.get('/extensions/transitions', async (req, res, next) => {
+        try {
+            const lastBlockCache = req.resolver.resolve<LastBlockCache>(LastBlockCache);
+            const TranisitionManager = req.resolver.resolve(TransitionManager);
+            const blockNum = lastBlockCache.value?.block_num ?? 0;
+            const statuses = TranisitionManager.getTransitionPointsStatusesAtBlock(blockNum);
+            res.status(200).json({
+                block_num: blockNum,
+                transition_points: statuses,
+            });
+        } catch (err) {
+            next(err);
+        }
+    });
+}


### PR DESCRIPTION
Adds an endpoint to query the upcoming transition block numbers, and adds a table on the home page to show them. This should help operators know when they need to update their nodes by.