### PR TITLE
Release v1.1.2 (bug fix)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - "validator"
     restart: on-failure
     environment:
-      VERSION: "${VERSION:-1.1.1}"
+      VERSION: "${VERSION:-1.1.2}"
       API_PORT: "3333"
       POSTGRES_PASSWORD: ${APP_PASSWORD:-validator}
       POSTGRES_USER: ${APP_USER:-validator}

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ replace_env() {
     sed -i "s/^$key=.*/$key=$value/g" "$file"
 }
 
-VERSION=v1.1.1
+VERSION=v1.1.2
 TARGET_DIR="SPS-Validator"
 
 set -e  # Exit on any error


### PR DESCRIPTION
Sets postgres container shared memory size to something higher so the repartition command doesn't fail sometimes.