### PR TITLE
Skip download prompt for automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You should still look through the manual setup steps so you understand how to st
 - `cd SPS-Validator`  : Change directory to the validator repository
 - `./run.sh stop`     : Ensure the validator is not currently running.
 - `cp .env-example .env`: If you haven't already run this. This will copy the default settings. You should update the new `.env` file with your `VALIDATOR_ACCOUNT` and `VALIDATOR_KEY` (posting). If you are JUST looking to earn license rewards, you should also set the `DB_BLOCK_RETENTION` variable to a minimum of `432000` to keep your database size small.
-- `./run.sh build`    : Build the validator.  This will deploy the database, run migrations and also download/deploy the snapshot.
+- `./run.sh build`    : Build the validator.  This will deploy the database, run migrations and also download/deploy the snapshot. Flags: `local-snapshot` (use existing snapshot without prompting), `no-cache` (rebuild without docker cache), `skip-snapshot` (skip snapshot entirely).
 - _(Note)_: If you receive an error like `Got permission denied while trying to connect to the Docker daemon socket`, follow the steps [here](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
 - `./run.sh start` or `./run.sh start all` : Start the validator. `all` will start the management UI as well.
 - You can go to http://localhost:3333/status to check that the validator is running.
@@ -126,7 +126,7 @@ You can take snapshots locally to take backups, and restore them without uploadi
 - You will get a `snapshot.zip` file in the git repositories root directory.
 - You can either upload this zip to a publicly accessible URL and share it, or just restore it locally.
 - To restore it locally, copy the `snapshot.zip` file into `./sqitch/validator-data-latest.zip`. (`cp ./snapshot.zip ./sqitch/validator-data-latest.zip`)
-- `./run.sh replay`: enter "n" when it asks if you want to download a fresh snapshot.
+- `./run.sh replay local-snapshot`: use the local snapshot without being prompted. Alternatively, run `./run.sh replay` and enter "n" when it asks if you want to download a fresh snapshot.
 
 ### Commands Reference
 
@@ -191,7 +191,7 @@ schema-breaking updates cannot be applied before the go-live block. To apply a s
 - `./run.sh stop` so your node stops restarting itself.
 - _(Note)_ You can run `./run.sh snapshot` to take a backup of your database before updating to be safe. If you need to restore this snapshot, see [snapshots](#snapshots).
 - You can now pull the latest version with `git fetch --tags -f && git checkout v{version}`.
-- `./run.sh build` to apply the latest database updates. When it asks if you want to download a new snapshot, you can enter "n".
+- `./run.sh build local-snapshot` to apply the latest database updates using the existing local snapshot. Alternatively, run `./run.sh build` and enter "n" when it asks if you want to download a new snapshot.
 - Remove the `KILL_BLOCK` from your .env file
 - `./run.sh rebuild_service validator` to rebuild the validator with the latest updates. This will also start the validator.
 - `./run.sh rebuild_service ui` if you want to rebuild the UI.

--- a/run.sh
+++ b/run.sh
@@ -207,25 +207,41 @@ replay() {
     then
         stop
         _destroy
-        build "$1" "$2"
+        build "$@"
         start "all"
     fi
 }
 
 # skip-snapshot works technically, but will result in a broken build
 build() {
-    if [[ $1 == "skip-snapshot" ]] || [[ $2 == "skip-snapshot" ]]; then
+    local args=("$@")
+    local has_skip_snapshot=false
+    local has_no_cache=false
+    local has_local_snapshot=false
+    for arg in "${args[@]}"; do
+        case "$arg" in
+            skip-snapshot) has_skip_snapshot=true ;;
+            no-cache) has_no_cache=true ;;
+            local-snapshot) has_local_snapshot=true ;;
+        esac
+    done
+
+    if [[ $has_skip_snapshot == true ]]; then
         echo "Skipping snapshot"
         echo "Running migrations. This could take several minutes..."
-        if [[ $1 == "no-cache" ]] || [[ $2 == "no-cache" ]]; then
+        if [[ $has_no_cache == true ]]; then
             docker_compose build --no-cache validator-sqitch
         else
             docker_compose build validator-sqitch
         fi
     else
-        dl_snapshot "$1"
+        if [[ $has_local_snapshot == true ]]; then
+            dl_snapshot "local-snapshot"
+        else
+            dl_snapshot
+        fi
         echo "Running migrations. This could take several minutes..."
-        if [[ $1 == "no-cache" ]] || [[ $2 == "no-cache" ]]; then
+        if [[ $has_no_cache == true ]]; then
             docker_compose build --build-arg snapshot="$SNAPSHOT_FILE" --no-cache validator-sqitch
         else
             docker_compose build --build-arg snapshot="$SNAPSHOT_FILE" validator-sqitch
@@ -235,16 +251,25 @@ build() {
 }
 
 dl_snapshot() {
+    local local_snapshot="$1"
     SNAPSHOT="$SQITCH_DIR/$SNAPSHOT_FILE"
     if [[ -f "$SNAPSHOT" ]]; then
-        read -p "Snapshot file already exists. Do you want to replace it and download a new one? (y/n)" -n 1 -r
-        echo    # (optional) move to a new line
-        if [[ $REPLY =~ ^[Yy]$ ]]
-        then
-            sudo rm -f "$SNAPSHOT"
-            _dl_snapshot
+        if [[ $local_snapshot == "local-snapshot" ]]; then
+            echo "Using existing local snapshot file."
+        else
+            read -p "Snapshot file already exists. Do you want to replace it and download a new one? (y/n)" -n 1 -r
+            echo    # (optional) move to a new line
+            if [[ $REPLY =~ ^[Yy]$ ]]
+            then
+                sudo rm -f "$SNAPSHOT"
+                _dl_snapshot
+            fi
         fi
     else
+        if [[ $local_snapshot == "local-snapshot" ]]; then
+            echo "Error: local-snapshot specified but no snapshot file found at $SNAPSHOT"
+            exit 1
+        fi
         _dl_snapshot
     fi
 }
@@ -394,7 +419,7 @@ help() {
     echo "    restart                       - runs stop + start"
     echo "    destroy                       - runs stop and deletes local database"
     echo "    replay                        - stops docker (if exists), deletes local database and runs build + start"
-    echo "    build                         - runs dl_snapshot + database migrations"
+    echo "    build [local-snapshot] [no-cache] [skip-snapshot] - runs dl_snapshot + database migrations. local-snapshot uses existing snapshot without prompting. no-cache rebuilds without docker cache. skip-snapshot skips snapshot entirely"
     echo "    dl_snapshot                   - downloads snapshot if it doesn't exists locally"
     echo "    snapshot                      - creates a snapshot of the current database."
     echo "    logs                          - trails the last 30 lines of logs"
@@ -427,10 +452,10 @@ case $1 in
         destroy
     ;;
     replay)
-        replay "$2" "$3"
+        replay "${@:2}"
     ;;
     build)
-        build "$2" "$3"
+        build "${@:2}"
     ;;
     dl_snapshot)
         dl_snapshot


### PR DESCRIPTION
Currently when building you must confirm whether you want to download a new snapshot or not. This prevents the process from being subject to automation.

This commit adds the `local-snapshot` flag which uses the locally available snapshot without needing to confirm in a prompt. This allows the automation of snapshots.