### PR TITLE
Skip snapshot prompt for automation

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -122,6 +122,38 @@ snapshot() {
     fi
 }
 
+snapshot_auto() {
+    echo "Stopping validator"
+    stop "validator"
+
+    echo "Creating snapshot"
+    run_psql -c "SELECT snapshot.freshsnapshot(TRUE);"
+
+    echo "Dumping snapshot to file"
+    docker_compose exec -e PGPASSWORD="$APP_PASSWORD" pg pg_dump \
+        --no-owner --no-acl \
+        --no-comments --no-publications --no-security-labels \
+        --schema snapshot \
+        --no-subscriptions --no-tablespaces --data-only \
+        --host "127.0.0.1" \
+        --username "$APP_USER" \
+        "${APP_DATABASE}" > snapshot.sql
+
+    CHANGE=$(run_psql -t -c "SELECT change FROM sqitch.changes WHERE project = 'splinterlands-validator' ORDER BY committed_at DESC LIMIT 1")
+    CHANGE=$(echo "$CHANGE" | xargs echo -n)
+    echo "Latest change: $CHANGE"
+    sed -i "1s/^/-- to_change:$CHANGE\n/" snapshot.sql
+
+    echo "Snapshot created. Zipping snapshot"
+    zip snapshot.zip snapshot.sql
+    rm snapshot.sql
+    echo "Snapshot zipped."
+
+    echo "Starting validator"
+    start "validator-silent"
+    echo "Snapshot process complete."
+}
+
 repartition_tables() {
     # confirm they want to do this
     echo "Repartioning only has to be done if your database existed before version v1.1.1, or if you have restored a snapshot from before that version."
@@ -397,6 +429,7 @@ help() {
     echo "    build                         - runs dl_snapshot + database migrations"
     echo "    dl_snapshot                   - downloads snapshot if it doesn't exists locally"
     echo "    snapshot                      - creates a snapshot of the current database."
+    echo "    snapshot-auto                 - non-interactive: stops validator, creates snapshot, restarts validator"
     echo "    logs                          - trails the last 30 lines of logs"
     echo "    status                        - checks your validator node status and registration status"
     echo "    repartition_tables            - helper command to repartition the partitioned database tables. only needed if upgrading a database from before v1.1.1 or if restoring a snapshot from before v1.1.1"
@@ -437,6 +470,9 @@ case $1 in
     ;;
     snapshot)
         snapshot
+    ;;
+    snapshot-auto)
+        snapshot_auto
     ;;
     logs)
         logs


### PR DESCRIPTION
Currently you must answer an interactive prompt to create a snapshot. This prevents the process from being subject to automation.

This commit adds the `snapshot_auto` flag which creates a full snapshot without needing to answer a prompt. This allows the automation of snapshots.