### PR TITLE
Fix issues with token precision

### DIFF
--- a/apps/sps-validator/src/sps/actions/promises/delegation_offer_promise.test.ts
+++ b/apps/sps-validator/src/sps/actions/promises/delegation_offer_promise.test.ts
@@ -951,6 +951,145 @@ describe('delegation_offer partial fills', () => {
         expect(rental!.status).toBe('active');
     });
 
+    test.dbOnly('final 3-decimal fill after drift fails before precision fix transition', async () => {
+        const mutableTransitionPoints = transitionPoints.transition_points as { token_precision_fix: number; delegation_offer_block: number };
+        const originalPrecisionBlock = mutableTransitionPoints.token_precision_fix;
+        const precisionBlock = transitionPoints.transition_points.delegation_offer_block + 20;
+        mutableTransitionPoints.token_precision_fix = precisionBlock;
+
+        try {
+            const txId = 'tx-qty-remaining-precision-pre';
+            await fixture.testHelper.setStaked(lender, 100);
+
+            await fixture.opsHelper.processOp(
+                'create_promise',
+                lender,
+                {
+                    type: 'delegation_offer',
+                    controllers: [controller],
+                    params: {
+                        token: TOKENS.SPSP,
+                        qty: 100,
+                        lender,
+                        price: 0.001,
+                    },
+                },
+                { block_num: precisionBlock - 2, transaction: txId },
+            );
+
+            await fixture.opsHelper.processOp(
+                'fulfill_promise',
+                controller,
+                {
+                    id: txId,
+                    type: 'delegation_offer',
+                    metadata: {
+                        borrower,
+                        rental_id: 'rental-precision-pre-1',
+                        qty: 99.9,
+                        expiration_blocks: 100000,
+                    },
+                },
+                { block_num: precisionBlock - 1 },
+            );
+
+            await fixture.opsHelper.processOp(
+                'fulfill_promise',
+                controller,
+                {
+                    id: txId,
+                    type: 'delegation_offer',
+                    metadata: {
+                        borrower,
+                        rental_id: 'rental-precision-pre-2',
+                        qty: 0.1,
+                        expiration_blocks: 100000,
+                    },
+                },
+                { block_num: precisionBlock - 1 },
+            );
+
+            const promise = await fixture.testHelper.getPromise('delegation_offer', txId);
+            const finalRental = await fixture.testHelper.getRentalDelegation('rental-precision-pre-2');
+
+            expect(promise!.status).toBe('open');
+            expect((promise!.params as any).qty_remaining).toBe(0.09999999999999432);
+            expect(finalRental).toBeNull();
+        } finally {
+            mutableTransitionPoints.token_precision_fix = originalPrecisionBlock;
+        }
+    });
+
+    test.dbOnly('final 3-decimal fill after drift completes after precision fix transition', async () => {
+        const mutableTransitionPoints = transitionPoints.transition_points as { token_precision_fix: number; delegation_offer_block: number };
+        const originalPrecisionBlock = mutableTransitionPoints.token_precision_fix;
+        const precisionBlock = transitionPoints.transition_points.delegation_offer_block + 20;
+        mutableTransitionPoints.token_precision_fix = precisionBlock;
+
+        try {
+            const txId = 'tx-qty-remaining-precision-post';
+            await fixture.testHelper.setStaked(lender, 100);
+
+            await fixture.opsHelper.processOp(
+                'create_promise',
+                lender,
+                {
+                    type: 'delegation_offer',
+                    controllers: [controller],
+                    params: {
+                        token: TOKENS.SPSP,
+                        qty: 100,
+                        lender,
+                        price: 0.001,
+                    },
+                },
+                { block_num: precisionBlock, transaction: txId },
+            );
+
+            await fixture.opsHelper.processOp(
+                'fulfill_promise',
+                controller,
+                {
+                    id: txId,
+                    type: 'delegation_offer',
+                    metadata: {
+                        borrower,
+                        rental_id: 'rental-precision-post-1',
+                        qty: 99.9,
+                        expiration_blocks: 100000,
+                    },
+                },
+                { block_num: precisionBlock + 1 },
+            );
+
+            await fixture.opsHelper.processOp(
+                'fulfill_promise',
+                controller,
+                {
+                    id: txId,
+                    type: 'delegation_offer',
+                    metadata: {
+                        borrower,
+                        rental_id: 'rental-precision-post-2',
+                        qty: 0.1,
+                        expiration_blocks: 100000,
+                    },
+                },
+                { block_num: precisionBlock + 2 },
+            );
+
+            const promise = await fixture.testHelper.getPromise('delegation_offer', txId);
+            const finalRental = await fixture.testHelper.getRentalDelegation('rental-precision-post-2');
+
+            expect(promise!.status).toBe('completed');
+            expect((promise!.params as any).qty_remaining).toBe(0);
+            expect(finalRental).not.toBeNull();
+            expect(finalRental!.qty).toBe('0.100');
+        } finally {
+            mutableTransitionPoints.token_precision_fix = originalPrecisionBlock;
+        }
+    });
+
     test.dbOnly('partial fill writes a history record even though status stays open', async () => {
         const blockNum = getBlockAfterTransition();
         const txId = 'tx-partial-history';

--- a/apps/sps-validator/src/sps/actions/promises/delegation_offer_promise.test.ts
+++ b/apps/sps-validator/src/sps/actions/promises/delegation_offer_promise.test.ts
@@ -141,6 +141,84 @@ describe('After controller_creation_block transition', () => {
         });
     });
 
+    test.dbOnly('delegation_offer precision validation uses configured token_precision_fix transition', async () => {
+        const mutableTransitionPoints = transitionPoints.transition_points as { token_precision_fix: number; delegation_offer_block: number };
+        const originalPrecisionBlock = mutableTransitionPoints.token_precision_fix;
+        const precisionBlock = transitionPoints.transition_points.delegation_offer_block + 20;
+        mutableTransitionPoints.token_precision_fix = precisionBlock;
+
+        try {
+            await fixture.testHelper.setStaked(lender, 100);
+
+            await expect(
+                fixture.opsHelper.processOp(
+                    'create_promise',
+                    lender,
+                    {
+                        type: 'delegation_offer',
+                        controllers: [controller],
+                        params: {
+                            token: TOKENS.SPSP,
+                            qty: 99.9,
+                            lender,
+                            price: 0.001,
+                        },
+                    },
+                    { block_num: precisionBlock - 1, transaction: 'precision-before-first' },
+                ),
+            ).resolves.toBeUndefined();
+
+            await expect(
+                fixture.opsHelper.processOp(
+                    'create_promise',
+                    lender,
+                    {
+                        type: 'delegation_offer',
+                        controllers: [controller],
+                        params: {
+                            token: TOKENS.SPSP,
+                            qty: 0.1,
+                            lender,
+                            price: 0.001,
+                        },
+                    },
+                    { block_num: precisionBlock - 1, transaction: 'precision-before-second' },
+                ),
+            ).resolves.toBeUndefined();
+
+            expect(await fixture.testHelper.getPromise('delegation_offer', 'precision-before-second')).toBeNull();
+
+            await expect(
+                fixture.opsHelper.processOp(
+                    'create_promise',
+                    lender,
+                    {
+                        type: 'delegation_offer',
+                        controllers: [controller],
+                        params: {
+                            token: TOKENS.SPSP,
+                            qty: 0.1,
+                            lender,
+                            price: 0.001,
+                        },
+                    },
+                    { block_num: precisionBlock, transaction: 'precision-after-second' },
+                ),
+            ).resolves.toBeUndefined();
+
+            const promise = await fixture.testHelper.getPromise('delegation_offer', 'precision-after-second');
+            expect(promise).not.toBeNull();
+            expect(promise!.params).toEqual(
+                expect.objectContaining({
+                    qty: 0.1,
+                    qty_remaining: 0.1,
+                }),
+            );
+        } finally {
+            mutableTransitionPoints.token_precision_fix = originalPrecisionBlock;
+        }
+    });
+
     test.dbOnly('promise ID is optional after transition (auto-generated)', async () => {
         const blockNum = getBlockAfterTransition();
         const txId = 'test-tx-123';

--- a/apps/sps-validator/src/sps/actions/tokens/delegate_tokens.test.ts
+++ b/apps/sps-validator/src/sps/actions/tokens/delegate_tokens.test.ts
@@ -2,6 +2,7 @@ import { emoji_payload, garbage_payload } from '../../../__tests__/db-helpers';
 import { container } from '../../../__tests__/test-composition-root';
 import { Fixture } from '../../../__tests__/action-fixture';
 import { TOKENS } from '../../features/tokens';
+import { TransitionCfg } from '../../features/transition';
 
 const fixture = container.resolve(Fixture);
 const DELEGATION_ACCOUNT = '$DELEGATION';
@@ -11,6 +12,7 @@ const delegatorWithoutAuthority = 'steemmonstersauth2';
 const delegator = 'steemmonsters';
 const delegatee = 'steemmonsters2';
 const system_delegatee = '$SOULKEEP';
+let transitionPoints: TransitionCfg = null!;
 
 beforeAll(async () => {
     await fixture.init();
@@ -36,6 +38,7 @@ beforeEach(async () => {
     await fixture.testHelper.setDelegatedIn(DELEGATION_ACCOUNT, 0);
 
     await fixture.loader.load();
+    transitionPoints = container.resolve(TransitionCfg);
 });
 
 afterAll(async () => {
@@ -89,26 +92,70 @@ test.dbOnly('Simple delegate tokens.', async () => {
 
 test.dbOnly('Delegate remaining 3-decimal balance when floating point math drifts below requested quantity.', async () => {
     await expect(
-        fixture.opsHelper.processOp('delegate_tokens', delegator, {
-            token: 'SPSP',
-            to: delegatee,
-            qty: 99.9,
-        }),
+        fixture.opsHelper.processOp(
+            'delegate_tokens',
+            delegator,
+            {
+                token: 'SPSP',
+                to: delegatee,
+                qty: 99.9,
+            },
+            { block_num: transitionPoints.transition_points.token_precision_fix },
+        ),
     ).resolves.toBeUndefined();
 
     await expect(
-        fixture.opsHelper.processOp('delegate_tokens', delegator, {
-            token: 'SPSP',
-            to: system_delegatee,
-            qty: 0.1,
-        }),
+        fixture.opsHelper.processOp(
+            'delegate_tokens',
+            delegator,
+            {
+                token: 'SPSP',
+                to: system_delegatee,
+                qty: 0.1,
+            },
+            { block_num: transitionPoints.transition_points.token_precision_fix },
+        ),
     ).resolves.toBeUndefined();
 
     const active_delegation_record = (await fixture.testHelper.getActiveDelegationRecord(delegator, system_delegatee, TOKENS.SPSP))!;
     const delegator_SPSP_OUT_balance_after = (await fixture.testHelper.getDummyToken(delegator, TOKENS.SPSP_OUT))!.balance;
 
-    expect(Number(active_delegation_record.amount)).toBeCloseTo(0.1);
-    expect(delegator_SPSP_OUT_balance_after).toBeCloseTo(initial_staked_amount);
+    expect(active_delegation_record.amount).toBe('0.100');
+    expect(delegator_SPSP_OUT_balance_after).toBe(100);
+});
+
+test.dbOnly('Delegate remaining 3-decimal balance fails before precision fix transition.', async () => {
+    await expect(
+        fixture.opsHelper.processOp(
+            'delegate_tokens',
+            delegator,
+            {
+                token: 'SPSP',
+                to: delegatee,
+                qty: 99.9,
+            },
+            { block_num: transitionPoints.transition_points.token_precision_fix - 1 },
+        ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+        fixture.opsHelper.processOp(
+            'delegate_tokens',
+            delegator,
+            {
+                token: 'SPSP',
+                to: system_delegatee,
+                qty: 0.1,
+            },
+            { block_num: transitionPoints.transition_points.token_precision_fix - 1 },
+        ),
+    ).resolves.toBeUndefined();
+
+    const active_delegation_record = await fixture.testHelper.getActiveDelegationRecord(delegator, system_delegatee, TOKENS.SPSP);
+    const delegator_SPSP_OUT_balance_after = (await fixture.testHelper.getDummyToken(delegator, TOKENS.SPSP_OUT))!.balance;
+
+    expect(active_delegation_record).toBeNull();
+    expect(delegator_SPSP_OUT_balance_after).toBe(99.9);
 });
 
 test.dbOnly('Simple delegate tokens to whitelisted system account.', async () => {

--- a/apps/sps-validator/src/sps/actions/tokens/delegate_tokens.test.ts
+++ b/apps/sps-validator/src/sps/actions/tokens/delegate_tokens.test.ts
@@ -87,6 +87,30 @@ test.dbOnly('Simple delegate tokens.', async () => {
     expect(sysacc_SPSP_IN_balance_after).toBe(-amount_to_delegate);
 });
 
+test.dbOnly('Delegate remaining 3-decimal balance when floating point math drifts below requested quantity.', async () => {
+    await expect(
+        fixture.opsHelper.processOp('delegate_tokens', delegator, {
+            token: 'SPSP',
+            to: delegatee,
+            qty: 99.9,
+        }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+        fixture.opsHelper.processOp('delegate_tokens', delegator, {
+            token: 'SPSP',
+            to: system_delegatee,
+            qty: 0.1,
+        }),
+    ).resolves.toBeUndefined();
+
+    const active_delegation_record = (await fixture.testHelper.getActiveDelegationRecord(delegator, system_delegatee, TOKENS.SPSP))!;
+    const delegator_SPSP_OUT_balance_after = (await fixture.testHelper.getDummyToken(delegator, TOKENS.SPSP_OUT))!.balance;
+
+    expect(Number(active_delegation_record.amount)).toBeCloseTo(0.1);
+    expect(delegator_SPSP_OUT_balance_after).toBeCloseTo(initial_staked_amount);
+});
+
 test.dbOnly('Simple delegate tokens to whitelisted system account.', async () => {
     const amount_to_delegate = 50;
 

--- a/apps/sps-validator/src/sps/actions/tokens/undelegate_tokens.test.ts
+++ b/apps/sps-validator/src/sps/actions/tokens/undelegate_tokens.test.ts
@@ -2,6 +2,7 @@ import { emoji_payload, garbage_payload } from '../../../__tests__/db-helpers';
 import { container } from '../../../__tests__/test-composition-root';
 import { Fixture } from '../../../__tests__/action-fixture';
 import { TOKENS } from '../../features/tokens';
+import { TransitionCfg } from '../../features/transition';
 
 const fixture = container.resolve(Fixture);
 const DELEGATION_ACCOUNT = '$DELEGATION';
@@ -11,6 +12,7 @@ const delegatorWithoutAuthority = 'steemmonstersauth2';
 const delegator = 'steemmonsters';
 const delegatee = 'steemmonsters2';
 const amount_delegated = 100;
+let transitionPoints: TransitionCfg = null!;
 
 beforeAll(async () => {
     await fixture.init();
@@ -34,6 +36,7 @@ beforeEach(async () => {
     await fixture.testHelper.setActiveDelegationRecord(delegator, delegatee, TOKENS.SPSP, amount_delegated);
 
     await fixture.loader.load();
+    transitionPoints = container.resolve(TransitionCfg);
 });
 
 afterAll(async () => {
@@ -200,6 +203,86 @@ test.dbOnly('undelegate more than delegated amount fails.', async () => {
     expect(Number(active_delegation_record_after.amount)).toBe(amount_delegated);
     expect(active_delegation_record_after.last_undelegation_date).toBeNull();
     expect(active_delegation_record_after.last_undelegation_tx).toBeNull();
+});
+
+test.dbOnly('Undelegate remaining 3-decimal non-rental amount fails before precision fix transition.', async () => {
+    await fixture.testHelper.insertRentalDelegation({
+        id: 'rental-precision-pre',
+        promise_type: 'delegation_offer',
+        promise_ext_id: 'offer-precision-pre',
+        lender: delegator,
+        borrower: delegatee,
+        token: TOKENS.SPSP,
+        qty: '99.900',
+        expiration_block: transitionPoints.transition_points.token_precision_fix + 1000,
+        start_block: transitionPoints.transition_points.token_precision_fix - 1000,
+        expiration_blocks: 2000,
+        status: 'active',
+    });
+
+    const block_time = new Date();
+    block_time.setTime(block_time.getTime() + 8 * 24 * 60 * 60 * 1000);
+
+    await expect(
+        fixture.opsHelper.processOp(
+            'undelegate_tokens',
+            delegator,
+            {
+                token: 'SPSP',
+                from: delegatee,
+                qty: 0.1,
+            },
+            { block_num: transitionPoints.transition_points.token_precision_fix - 1, block_time },
+        ),
+    ).resolves.toBeUndefined();
+
+    const active_delegation_record_after = (await fixture.testHelper.getActiveDelegationRecord(delegator, delegatee, TOKENS.SPSP))!;
+
+    expect(active_delegation_record_after.amount).toBe('100.000');
+    expect(active_delegation_record_after.last_undelegation_date).toBeNull();
+    expect(active_delegation_record_after.last_undelegation_tx).toBeNull();
+});
+
+test.dbOnly('Undelegate remaining 3-decimal non-rental amount succeeds after precision fix transition.', async () => {
+    await fixture.testHelper.insertRentalDelegation({
+        id: 'rental-precision-post',
+        promise_type: 'delegation_offer',
+        promise_ext_id: 'offer-precision-post',
+        lender: delegator,
+        borrower: delegatee,
+        token: TOKENS.SPSP,
+        qty: '99.900',
+        expiration_block: transitionPoints.transition_points.token_precision_fix + 1000,
+        start_block: transitionPoints.transition_points.token_precision_fix - 1000,
+        expiration_blocks: 2000,
+        status: 'active',
+    });
+
+    const block_time = new Date();
+    block_time.setTime(block_time.getTime() + 8 * 24 * 60 * 60 * 1000);
+
+    await expect(
+        fixture.opsHelper.processOp(
+            'undelegate_tokens',
+            delegator,
+            {
+                token: 'SPSP',
+                from: delegatee,
+                qty: 0.1,
+            },
+            { block_num: transitionPoints.transition_points.token_precision_fix, block_time },
+        ),
+    ).resolves.toBeUndefined();
+
+    const active_delegation_record_after = (await fixture.testHelper.getActiveDelegationRecord(delegator, delegatee, TOKENS.SPSP))!;
+    const delegator_SPSP_OUT_balance_after = (await fixture.testHelper.getDummyToken(delegator, TOKENS.SPSP_OUT))!.balance;
+    const delegatee_SPSP_IN_balance_after = (await fixture.testHelper.getDummyToken(delegatee, TOKENS.SPSP_IN))!.balance;
+
+    expect(active_delegation_record_after.amount).toBe('99.900');
+    expect(active_delegation_record_after.last_undelegation_date).toBeTruthy();
+    expect(active_delegation_record_after.last_undelegation_tx).toBeTruthy();
+    expect(delegator_SPSP_OUT_balance_after).toBe(99.9);
+    expect(delegatee_SPSP_IN_balance_after).toBe(99.9);
 });
 
 test.dbOnly('undelegate negative amount fails.', async () => {

--- a/apps/sps-validator/src/sps/actions/tokens/unstake_tokens.test.ts
+++ b/apps/sps-validator/src/sps/actions/tokens/unstake_tokens.test.ts
@@ -3,8 +3,10 @@ import { container } from '../../../__tests__/test-composition-root';
 import { Fixture } from '../../../__tests__/action-fixture';
 import { ConfigEntity } from '@steem-monsters/splinterlands-validator';
 import { TOKENS } from '../../features/tokens';
+import { TransitionCfg } from '../../features/transition';
 
 const fixture = container.resolve(Fixture);
+let transitionPoints: TransitionCfg = null!;
 
 afterAll(async () => {
     await fixture.dispose();
@@ -20,6 +22,7 @@ beforeEach(async () => {
     await fixture.handle.query(ConfigEntity).where('group_name', 'sps').andWhere('name', 'unstaking_interval_seconds').updateItem({ value: '1' });
     await fixture.handle.query(ConfigEntity).where('group_name', 'sps').andWhere('name', 'unstaking_periods').updateItem({ value: '1' });
     await fixture.loader.load();
+    transitionPoints = container.resolve(TransitionCfg);
 });
 
 test.dbOnly('Garbage data for unstake_tokens does not crash.', () => {
@@ -71,13 +74,36 @@ test.dbOnly('Can unstake remaining 3-decimal balance when floating point math dr
     await fixture.testHelper.setStaked('steemmonsters', 100);
     await fixture.testHelper.setDelegatedOut('steemmonsters', 99.9);
     await expect(
-        fixture.opsHelper.processOp('unstake_tokens', 'steemmonsters', {
-            token: TOKENS.SPS,
-            qty: 0.1,
-        }),
+        fixture.opsHelper.processOp(
+            'unstake_tokens',
+            'steemmonsters',
+            {
+                token: TOKENS.SPS,
+                qty: 0.1,
+            },
+            { block_num: transitionPoints.transition_points.token_precision_fix },
+        ),
     ).resolves.toBeUndefined();
     const unstaking = await fixture.testHelper.getUnstakingRecord('steemmonsters');
-    expect(Number(unstaking?.total_qty)).toBeCloseTo(0.1);
+    expect(unstaking?.total_qty).toBe('0.100');
+});
+
+test.dbOnly('Cannot unstake remaining 3-decimal balance before precision fix transition', async () => {
+    await fixture.testHelper.setStaked('steemmonsters', 100);
+    await fixture.testHelper.setDelegatedOut('steemmonsters', 99.9);
+    await expect(
+        fixture.opsHelper.processOp(
+            'unstake_tokens',
+            'steemmonsters',
+            {
+                token: TOKENS.SPS,
+                qty: 0.1,
+            },
+            { block_num: transitionPoints.transition_points.token_precision_fix - 1 },
+        ),
+    ).resolves.toBeUndefined();
+    const unstaking = await fixture.testHelper.getUnstakingRecord('steemmonsters');
+    expect(unstaking).toBeNull();
 });
 
 test.dbOnly('Double unstake', async () => {

--- a/apps/sps-validator/src/sps/actions/tokens/unstake_tokens.test.ts
+++ b/apps/sps-validator/src/sps/actions/tokens/unstake_tokens.test.ts
@@ -67,6 +67,19 @@ test.dbOnly('Cannot unstake more than (staked - delegated) amount', async () => 
     expect(unstaking).toBeNull();
 });
 
+test.dbOnly('Can unstake remaining 3-decimal balance when floating point math drifts below requested quantity', async () => {
+    await fixture.testHelper.setStaked('steemmonsters', 100);
+    await fixture.testHelper.setDelegatedOut('steemmonsters', 99.9);
+    await expect(
+        fixture.opsHelper.processOp('unstake_tokens', 'steemmonsters', {
+            token: TOKENS.SPS,
+            qty: 0.1,
+        }),
+    ).resolves.toBeUndefined();
+    const unstaking = await fixture.testHelper.getUnstakingRecord('steemmonsters');
+    expect(Number(unstaking?.total_qty)).toBeCloseTo(0.1);
+});
+
 test.dbOnly('Double unstake', async () => {
     await fixture.testHelper.setStaked('steemmonsters', 20);
     await expect(

--- a/apps/sps-validator/src/sps/actions/tokens/unstake_tokens.ts
+++ b/apps/sps-validator/src/sps/actions/tokens/unstake_tokens.ts
@@ -12,10 +12,7 @@ import {
 import { unstake_tokens } from '../schema';
 import { SUPPORTED_TOKENS } from '../../features/tokens';
 import { MakeActionFactory, MakeRouter } from '../utils';
-
-const TOKEN_BALANCE_PRECISION = 3;
-
-const normalizeTokenBalance = (balance: number) => +balance.toFixed(TOKEN_BALANCE_PRECISION);
+import { TransitionManager } from '../../features/transition';
 
 export class UnstakeTokensAction extends Action<typeof unstake_tokens.actionSchema> {
     constructor(
@@ -24,6 +21,7 @@ export class UnstakeTokensAction extends Action<typeof unstake_tokens.actionSche
         index: number,
         private readonly balanceRepository: BalanceRepository,
         private readonly tokenUnstakingRepository: TokenUnstakingRepository,
+        private readonly transitionManager: TransitionManager,
     ) {
         super(unstake_tokens, op, data, index);
     }
@@ -50,7 +48,11 @@ export class UnstakeTokensAction extends Action<typeof unstake_tokens.actionSche
             const out_balance = await this.balanceRepository.getBalance(this.op.account, delegation_support.out_token, trx);
             unstaking_limit -= out_balance;
         }
-        unstaking_limit = normalizeTokenBalance(unstaking_limit);
+
+        const precisionFixEnabled = this.transitionManager.isTransitioned('token_precision_fix', this.op.block_num);
+        if (precisionFixEnabled) {
+            unstaking_limit = +unstaking_limit.toFixed(3);
+        }
 
         if (unstaking_limit < this.params.qty) {
             throw new ValidationError('Cannot unstake more than the currently available staked token balance.', this, ErrorType.InsufficientBalance);
@@ -73,5 +75,5 @@ export class UnstakeTokensAction extends Action<typeof unstake_tokens.actionSche
     }
 }
 
-const Builder = MakeActionFactory(UnstakeTokensAction, BalanceRepository, TokenUnstakingRepository);
+const Builder = MakeActionFactory(UnstakeTokensAction, BalanceRepository, TokenUnstakingRepository, TransitionManager);
 export const Router = MakeRouter(unstake_tokens.action_name, Builder);

--- a/apps/sps-validator/src/sps/actions/tokens/unstake_tokens.ts
+++ b/apps/sps-validator/src/sps/actions/tokens/unstake_tokens.ts
@@ -13,6 +13,10 @@ import { unstake_tokens } from '../schema';
 import { SUPPORTED_TOKENS } from '../../features/tokens';
 import { MakeActionFactory, MakeRouter } from '../utils';
 
+const TOKEN_BALANCE_PRECISION = 3;
+
+const normalizeTokenBalance = (balance: number) => +balance.toFixed(TOKEN_BALANCE_PRECISION);
+
 export class UnstakeTokensAction extends Action<typeof unstake_tokens.actionSchema> {
     constructor(
         op: OperationData,
@@ -46,6 +50,7 @@ export class UnstakeTokensAction extends Action<typeof unstake_tokens.actionSche
             const out_balance = await this.balanceRepository.getBalance(this.op.account, delegation_support.out_token, trx);
             unstaking_limit -= out_balance;
         }
+        unstaking_limit = normalizeTokenBalance(unstaking_limit);
 
         if (unstaking_limit < this.params.qty) {
             throw new ValidationError('Cannot unstake more than the currently available staked token balance.', this, ErrorType.InsufficientBalance);

--- a/apps/sps-validator/src/sps/convict-config.ts
+++ b/apps/sps-validator/src/sps/convict-config.ts
@@ -582,6 +582,12 @@ const schema = {
             default: 103680250,
             env: 'FIX_MULTI_UNDELEGATE_CRASH_TRANSITION_POINT',
         },
+        token_precision_fix: {
+            doc: 'Block number for the token_precision_fix transition',
+            format: 'nat',
+            default: 999999999,
+            env: 'TOKEN_PRECISION_FIX_TRANSITION_POINT',
+        },
         delegation_offer_block: {
             doc: 'Block number for enabling delegation offers',
             format: 'nat',

--- a/apps/sps-validator/src/sps/features/delegation/delegation_manager.ts
+++ b/apps/sps-validator/src/sps/features/delegation/delegation_manager.ts
@@ -30,4 +30,8 @@ export class SpsDelegationManager extends DelegationManager {
     override shouldGroupTransfersInMultiOps(block_num: number): boolean {
         return this.transitionManager.isTransitioned('fix_multi_undelegate_crash', block_num);
     }
+
+    protected override shouldNormalizeAvailableBalance(block_num: number): boolean {
+        return this.transitionManager.isTransitioned('token_precision_fix', block_num);
+    }
 }

--- a/apps/sps-validator/src/sps/features/delegation/delegation_offer_promises.ts
+++ b/apps/sps-validator/src/sps/features/delegation/delegation_offer_promises.ts
@@ -7,10 +7,12 @@ import {
 } from '@steem-monsters/splinterlands-validator';
 import { inject, injectable } from 'tsyringe';
 import { SpsConfigLoader } from '../../config';
+import { TransitionManager } from '../transition';
 
 @injectable()
 export class SpsDelegationOfferPromiseHandler extends DelegationOfferPromiseHandler {
     constructor(
+        @inject(TransitionManager) private readonly transitionManager: TransitionManager,
         @inject(DelegationManager) delegationManager: DelegationManager,
         @inject(RentalDelegationRepository) rentalDelegationRepository: RentalDelegationRepository,
         @inject(PromiseRepository) promiseRepository: PromiseRepository,
@@ -20,5 +22,9 @@ export class SpsDelegationOfferPromiseHandler extends DelegationOfferPromiseHand
             delegation_promise_account: '$DELEGATION_PROMISES',
         };
         super(opts, delegationManager, rentalDelegationRepository, promiseRepository, configLoader);
+    }
+
+    protected override shouldNormalizeDelegationOfferQty(block_num: number): boolean {
+        return this.transitionManager.isTransitioned('token_precision_fix', block_num);
     }
 }

--- a/apps/sps-validator/src/sps/features/transition/transitions.ts
+++ b/apps/sps-validator/src/sps/features/transition/transitions.ts
@@ -15,6 +15,7 @@ export const TransitionPointDescriptions = {
         'Transition point for changing the SPS staking reward algorithm and adjusting reward pool balances. This update also adds consecutive missed block tracking and double spend protection in token_transfer and token_transfer_multi ops. This is a one-time transition point that is part of version 1.3.0. Please see https://peakd.com/spsproposal/@clayboyn/sps-governance-proposal-adjust-token-distribution-strategy',
     fix_multi_undelegate_crash:
         'Transition point for fixing a crash that can occur when undelegating sps from the same account multiple times in the same tx. This is a one-time transition point that is part of version 1.3.1.',
+    token_precision_fix: 'Transition point for normalizing delegation and unstake balance precision to avoid binary floating point drift when validating available SPSP.',
     delegation_offer_block: 'Transition point for enabling delegation offer creation.',
 } as const;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "validator-monorepo",
-    "version": "0.0.9",
+    "version": "1.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "validator-monorepo",
-            "version": "0.0.9",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "@abraham/reflection": "0.10.0",

--- a/validator/src/entities/tokens/active_delegations.ts
+++ b/validator/src/entities/tokens/active_delegations.ts
@@ -19,6 +19,9 @@ export type ActiveDelegationsEntry = {
 };
 
 const DELEGATION_ACCOUNT = '$DELEGATION';
+const TOKEN_BALANCE_PRECISION = 3;
+
+const normalizeTokenBalance = (balance: number) => +balance.toFixed(TOKEN_BALANCE_PRECISION);
 
 export class ActiveDelegationsRepository extends BaseRepository {
     public readonly table = getTableName(ActiveDelegationEntity);
@@ -58,11 +61,10 @@ export class ActiveDelegationsRepository extends BaseRepository {
         const token_balance = await this.balanceRepository.getBalance(player, token.token, trx);
         const delegated_balance = await this.balanceRepository.getBalance(player, token.delegation.out_token, trx);
         const balance = token_balance - delegated_balance;
-        if (!token.unstakes) return balance;
+        if (!token.unstakes) return normalizeTokenBalance(balance);
         const unstaking_record = await this.unstakingRepository.lookup(player, token.unstakes, trx);
-        const unstaking_balance = unstaking_record ? +(unstaking_record.total_qty - unstaking_record.total_unstaked) : 0;
-        // no precision??
-        return balance - unstaking_balance;
+        const unstaking_balance = unstaking_record ? unstaking_record.total_qty - unstaking_record.total_unstaked : 0;
+        return normalizeTokenBalance(balance - unstaking_balance);
     }
 
     public async delegate(action: IAction, delegator: string, delegatee: string, token: TokenSupportEntry, qty: number, skipDateUpdate?: boolean, trx?: Trx) {

--- a/validator/src/entities/tokens/active_delegations.ts
+++ b/validator/src/entities/tokens/active_delegations.ts
@@ -19,9 +19,6 @@ export type ActiveDelegationsEntry = {
 };
 
 const DELEGATION_ACCOUNT = '$DELEGATION';
-const TOKEN_BALANCE_PRECISION = 3;
-
-const normalizeTokenBalance = (balance: number) => +balance.toFixed(TOKEN_BALANCE_PRECISION);
 
 export class ActiveDelegationsRepository extends BaseRepository {
     public readonly table = getTableName(ActiveDelegationEntity);
@@ -61,10 +58,10 @@ export class ActiveDelegationsRepository extends BaseRepository {
         const token_balance = await this.balanceRepository.getBalance(player, token.token, trx);
         const delegated_balance = await this.balanceRepository.getBalance(player, token.delegation.out_token, trx);
         const balance = token_balance - delegated_balance;
-        if (!token.unstakes) return normalizeTokenBalance(balance);
+        if (!token.unstakes) return balance;
         const unstaking_record = await this.unstakingRepository.lookup(player, token.unstakes, trx);
-        const unstaking_balance = unstaking_record ? unstaking_record.total_qty - unstaking_record.total_unstaked : 0;
-        return normalizeTokenBalance(balance - unstaking_balance);
+        const unstaking_balance = unstaking_record ? +(unstaking_record.total_qty - unstaking_record.total_unstaked) : 0;
+        return balance - unstaking_balance;
     }
 
     public async delegate(action: IAction, delegator: string, delegatee: string, token: TokenSupportEntry, qty: number, skipDateUpdate?: boolean, trx?: Trx) {

--- a/validator/src/features/delegation/delegation_manager.ts
+++ b/validator/src/features/delegation/delegation_manager.ts
@@ -57,7 +57,15 @@ export class DelegationManager {
         private readonly rentalDelegationRepository: RentalDelegationRepository,
     ) {}
 
-    shouldGroupTransfersInMultiOps(block_num: number): boolean {
+    private normalizeAvailableBalance(balance: number, enabled?: boolean): number {
+        return enabled ? +balance.toFixed(3) : balance;
+    }
+
+    protected shouldNormalizeAvailableBalance(_block_num: number): boolean {
+        return false;
+    }
+
+    shouldGroupTransfersInMultiOps(_block_num: number): boolean {
         return false;
     }
 
@@ -112,7 +120,10 @@ export class DelegationManager {
         }
 
         // Check that the player has enough liquid tokens in their account
-        const available_balance = await this.delegationRepository.getAvailableBalance(request.from, tokenEntry, trx);
+        const available_balance = this.normalizeAvailableBalance(
+            await this.delegationRepository.getAvailableBalance(request.from, tokenEntry, trx),
+            this.shouldNormalizeAvailableBalance(action.op.block_num),
+        );
         if (available_balance < request.qty) {
             return Result.Err(new ValidationError(`Insufficient liquid ${request.token}.`, action, ErrorType.InsufficientBalance));
         }
@@ -164,7 +175,10 @@ export class DelegationManager {
 
         const qtyNeeded = delegations.reduce((acc, [_, qty]) => acc + qty, 0);
         // Check that the player has enough liquid tokens in their account
-        const available_balance = await this.delegationRepository.getAvailableBalance(request.from, tokenEntry, trx);
+        const available_balance = this.normalizeAvailableBalance(
+            await this.delegationRepository.getAvailableBalance(request.from, tokenEntry, trx),
+            this.shouldNormalizeAvailableBalance(action.op.block_num),
+        );
         if (available_balance < qtyNeeded) {
             return Result.Err(new ValidationError(`Insufficient liquid ${request.token}.`, action, ErrorType.InsufficientBalance));
         }

--- a/validator/src/features/delegation/delegation_manager.ts
+++ b/validator/src/features/delegation/delegation_manager.ts
@@ -57,7 +57,7 @@ export class DelegationManager {
         private readonly rentalDelegationRepository: RentalDelegationRepository,
     ) {}
 
-    private normalizeAvailableBalance(balance: number, enabled?: boolean): number {
+    private normalizeTokenComparisonAmount(balance: number, enabled?: boolean): number {
         return enabled ? +balance.toFixed(3) : balance;
     }
 
@@ -120,7 +120,7 @@ export class DelegationManager {
         }
 
         // Check that the player has enough liquid tokens in their account
-        const available_balance = this.normalizeAvailableBalance(
+        const available_balance = this.normalizeTokenComparisonAmount(
             await this.delegationRepository.getAvailableBalance(request.from, tokenEntry, trx),
             this.shouldNormalizeAvailableBalance(action.op.block_num),
         );
@@ -175,7 +175,7 @@ export class DelegationManager {
 
         const qtyNeeded = delegations.reduce((acc, [_, qty]) => acc + qty, 0);
         // Check that the player has enough liquid tokens in their account
-        const available_balance = this.normalizeAvailableBalance(
+        const available_balance = this.normalizeTokenComparisonAmount(
             await this.delegationRepository.getAvailableBalance(request.from, tokenEntry, trx),
             this.shouldNormalizeAvailableBalance(action.op.block_num),
         );
@@ -312,7 +312,7 @@ export class DelegationManager {
         if (!delegation) {
             return Result.Err(new ValidationError(`There is currently no ${token} tokens delegated from ${to} to ${from}.`, action, ErrorType.NoTokensDelegated));
         }
-        const undelegatableAmount = delegation.amount - rentalLockedQty;
+        const undelegatableAmount = this.normalizeTokenComparisonAmount(delegation.amount - rentalLockedQty, this.shouldNormalizeAvailableBalance(action.op.block_num));
         if (qty > undelegatableAmount) {
             return Result.Err(new ValidationError(`Cannot undelegate more than you have delegated.`, action, ErrorType.UndelegationAmountTooHigh));
         } else if (action.op.block_time.getTime() - delegation.last_delegation_date.getTime() < this.opts.undelegation_cooldown_ms) {

--- a/validator/src/features/delegation/delegation_offer_promises.ts
+++ b/validator/src/features/delegation/delegation_offer_promises.ts
@@ -130,6 +130,14 @@ export class DelegationOfferPromiseHandler extends PromiseHandler {
         return this.configWatch?.delegation_rental?.min_qty ?? this.opts.default_min_qty ?? DelegationOfferPromiseHandler.DEFAULT_MIN_QTY;
     }
 
+    private normalizeDelegationOfferQty(amount: number, enabled?: boolean): number {
+        return enabled ? +amount.toFixed(3) : amount;
+    }
+
+    protected shouldNormalizeDelegationOfferQty(_block_num: number): boolean {
+        return false;
+    }
+
     /**
      * Delegation offers are created directly by the lender, not by admins.
      */
@@ -295,7 +303,7 @@ export class DelegationOfferPromiseHandler extends PromiseHandler {
         const metadata = request.metadata as DelegationOfferFulfillMetadata;
         const fillQty = metadata.qty;
         const qtyRemaining = params.qty_remaining ?? params.qty;
-        const newQtyRemaining = qtyRemaining - fillQty;
+        const newQtyRemaining = this.normalizeDelegationOfferQty(qtyRemaining - fillQty, this.shouldNormalizeDelegationOfferQty(action.op.block_num));
         const eventLogs: EventLog[] = [];
 
         // 1. Undelegate the fill qty from the promises account back to the lender


### PR DESCRIPTION
Fix token precision rounding in delegation

Normalize token balances to 3 decimal places to prevent floating point drift

See issue:
<img width="1239" height="440" alt="image" src="https://github.com/user-attachments/assets/788cabd2-f0a4-4abc-957f-f6ef8e78dad5" />
